### PR TITLE
Specify correct attribute accessors

### DIFF
--- a/deploy_template/mygame/documentation/02-labels.md
+++ b/deploy_template/mygame/documentation/02-labels.md
@@ -108,7 +108,7 @@ Here is an example:
 ```ruby
 # Create type with ALL sprite properties AND primitive_marker
 class Label
-  attr_accessor :x, :y, :text, :size, :alignment, :r, :g, :b, :a
+  attr_accessor :x, :y, :text, :size_enum, :alignment_enum, :font, :r, :g, :b, :a
 
   def primitive_marker
     :label


### PR DESCRIPTION
This PR fixes the incorrect and missing attribute accessors needed for the `Label` class to work.