### PR TITLE
Document few accessors

### DIFF
--- a/dragon/args.rb
+++ b/dragon/args.rb
@@ -198,6 +198,7 @@ module GTK
       @render_targets[name]
     end
 
+    # @return [GTK::OutputsArray] The array of solids to render during current tick
     def solids
       @outputs.solids
     end
@@ -206,6 +207,7 @@ module GTK
       @outputs.static_solids
     end
 
+    # @return [GTK::OutputsArray] The array of sprites to render during current tick
     def sprites
       @outputs.sprites
     end
@@ -214,6 +216,7 @@ module GTK
       @outputs.static_sprites
     end
 
+    # @return [GTK::OutputsArray] The array of labels to render during current tick
     def labels
       @outputs.labels
     end
@@ -222,6 +225,7 @@ module GTK
       @outputs.static_labels
     end
 
+    # @return [GTK::OutputsArray] The array of lines to render during current tick
     def lines
       @outputs.lines
     end
@@ -230,6 +234,7 @@ module GTK
       @outputs.static_lines
     end
 
+    # @return [GTK::OutputsArray] The array of borders to render during current tick
     def borders
       @outputs.borders
     end


### PR DESCRIPTION
This PR adds simple documentation for few accessors as the first step to start the conversation.

Ideally, the documentation project would pull in the git submodule with the official open-sourced Ruby files and use the documentation comments directly from them, rather than having to recreate the dummy files just to create the documentation.

/cc @amirrajan 