### PR TITLE
Implement console tab autocompletion

### DIFF
--- a/dragon/console.rb
+++ b/dragon/console.rb
@@ -84,10 +84,8 @@ module GTK
       end
 
       def autocomplete
-        return unless last_period_index
-
         if !@last_autocomplete_prefix
-          @last_autocomplete_prefix = current_input_str[(last_period_index + 1)..-1]
+          @last_autocomplete_prefix = calc_autocomplete_prefix
 
           puts method_candidates(@last_autocomplete_prefix)
         else
@@ -98,7 +96,7 @@ module GTK
           candidate = candidate[0..-2] + " = " if candidate.end_with? '='
           @next_candidate_index += 1
           @next_candidate_index = 0 if @next_candidate_index >= candidates.length
-          @current_input_str = @current_input_str[0..last_period_index] + candidate.to_s
+          self.current_input_str = display_autocomplete_candidate(candidate)
         end
       end
 
@@ -113,8 +111,16 @@ module GTK
         current_input_str.rindex('.')
       end
 
+      def calc_autocomplete_prefix
+        if last_period_index
+          current_input_str[(last_period_index + 1)..-1]
+        else
+          current_input_str
+        end
+      end
+
       def current_object
-        return nil unless last_period_index
+        return Kernel unless last_period_index
 
         Kernel.eval(current_input_str[0...last_period_index])
       rescue NameError
@@ -123,6 +129,14 @@ module GTK
 
       def method_candidates(prefix)
         current_object.methods.map(&:to_s).select { |m| m.start_with? prefix }
+      end
+
+      def display_autocomplete_candidate(candidate)
+        if last_period_index
+          @current_input_str[0..last_period_index] + candidate.to_s
+        else
+          candidate.to_s
+        end
       end
 
       def reset_autocomplete


### PR DESCRIPTION
First key down on tab shows all instance methods with the currently typed prefix. All further key downs will cycle through the suggestions of the last typed prefix.

### Example:

Pressing tab having typed `$gtk.a` will display
```rb
["and", "associate", "analog_to_perc", "append_file", "argv=", "argv", "args"]
```

Next press will complete `$gtk.a` to `$gtk.and`, the one afterwards to `$gtk.associate` etc.
Typing or pressing enter will reset the current prefix.

As a little visual convenience setters are expanded from `object.setter=` to `object.setter = `

## Limitations / Points that still could be improved
- At the moment this only works with instance methods of the typed object/class and with global methods (methods of Kernel), global variables or classes are not supported (yet)
