### PR TITLE
Improve attr_sprite

### DIFF
--- a/dragon/attr_sprite.rb
+++ b/dragon/attr_sprite.rb
@@ -5,19 +5,19 @@
 # @private
 module AttrRect
   def left
-    @x
+    x
   end
 
   def right
-    @x + @w
+    x + w
   end
 
   def bottom
-    @y
+    y
   end
 
   def top
-    @y + @h
+    y + h
   end
 end
 
@@ -39,18 +39,18 @@ module AttrSprite
   end
 
   def x1
-    @x
+    x
   end
 
   def x1= value
-    @x = value
+    self.x = value
   end
 
   def y1
-    @y
+    y
   end
 
   def y1= value
-    @y = value
+    self.y = value
   end
 end

--- a/dragon/attr_sprite.rb
+++ b/dragon/attr_sprite.rb
@@ -4,16 +4,13 @@
 
 # @private
 module AttrRect
-  def left
-    x
+  def self.included(klass)
+    klass.alias_method :left, :x
+    klass.alias_method :bottom, :y
   end
 
   def right
     x + w
-  end
-
-  def bottom
-    y
   end
 
   def top
@@ -22,13 +19,14 @@ module AttrRect
 end
 
 module AttrSprite
-  include AttrRect
   include GTK::Geometry
 
   attr_accessor :x, :y, :w, :h, :path, :angle, :a, :r, :g, :b, :tile_x,
                 :tile_y, :tile_w, :tile_h, :flip_horizontally,
                 :flip_vertically, :angle_anchor_x, :angle_anchor_y, :id,
                 :source_x, :source_y, :source_w, :source_h
+
+  include AttrRect
 
   def primitive_marker
     :sprite
@@ -38,19 +36,8 @@ module AttrSprite
     self
   end
 
-  def x1
-    x
-  end
-
-  def x1= value
-    self.x = value
-  end
-
-  def y1
-    y
-  end
-
-  def y1= value
-    self.y = value
-  end
+  alias_method :x1, :x
+  alias_method :x1=, :x=
+  alias_method :y1, :y
+  alias_method :y1=, :y=
 end


### PR DESCRIPTION
The convenience methods that are calculated from the sprite attributes used the instance variables directly. When a class that uses `attr_sprite` overwrites any of those attributes with custom logic the derived properties will not return the right values.

I changed them to use the getter methods instead so subclasses properly calculate those values
