### PR TITLE
99-todo.md deprecated method documentation

### DIFF
--- a/deploy_template/mygame/documentation/03-solids-and-borders.md
+++ b/deploy_template/mygame/documentation/03-solids-and-borders.md
@@ -2,7 +2,7 @@
 
 Solids and Borders are great to use as place holders for sprites.
 
-## Sample Apps Releated to Solid/Borders Usage (ordered by size of codebase increasing)
+## Sample Apps Related to Solid/Borders Usage (ordered by size of codebase increasing)
 
 - 01_api_03_rects
 - 01_api_99_tech_demo (includes recording)

--- a/deploy_template/mygame/documentation/05-sprites.md
+++ b/deploy_template/mygame/documentation/05-sprites.md
@@ -29,7 +29,7 @@ args.outputs.sprites << [100, 100,    32,     64, "sprites/player.png"]
 
 ## Rotation / Angle
 
-Unlike `solids` and `borders`, sprites can be rotated. This is how you rotate a sprite 90 degress.
+Unlike `solids` and `borders`, sprites can be rotated. This is how you rotate a sprite 90 degrees.
 
 Note: All angles in DragonRuby Game Toolkit are represented in degrees (not radians).
 
@@ -99,7 +99,7 @@ args.outputs.sprites << [                 100,    # X
 
 A sprite can be flipped horizontally and vertically.
 
-This is a sprite that has been flipped horizontally. The sprites's angle, alpha, color saturations,
+This is a sprite that has been flipped horizontally. The sprite's angle, alpha, color saturations,
 and tile subdivision are unaltered.
 
 ```ruby
@@ -121,7 +121,7 @@ args.outputs.sprites << [                 100,    # X
                                         false]    # FLIP_VERTICALLY
 ```
 
-This is a sprite that has been flipped vertically. The sprites's angle, alpha, color saturations,
+This is a sprite that has been flipped vertically. The sprite's angle, alpha, color saturations,
 and tile subdivision are unaltered.
 
 ```ruby
@@ -147,8 +147,8 @@ args.outputs.sprites << [                 100,    # X
 
 A sprites center of rotation can be altered.
 
-This is a sprite that has its rotation center set to the top-middle. The sprites's angle, alpha, color saturations,
-tile subdivision, and projectsions are unaltered.
+This is a sprite that has its rotation center set to the top-middle. The sprite's angle, alpha, color saturations,
+tile subdivision, and projections are unaltered.
 
 ```ruby
 args.outputs.sprites << [                 100,    # X

--- a/deploy_template/mygame/documentation/06-keyboard.md
+++ b/deploy_template/mygame/documentation/06-keyboard.md
@@ -55,7 +55,7 @@ end
 
 # List of keys:
 
-These are the character and associated properities that will
+These are the character and associated properties that will
 be set to true.
 
 For example `A => :a, :shift` means that `args.inputs.keyboard.a`

--- a/deploy_template/mygame/documentation/08-controllers.md
+++ b/deploy_template/mygame/documentation/08-controllers.md
@@ -33,7 +33,7 @@ end
 
 # Truthy Keys
 
-You can access all triggered keys through `thruthy_keys` on `keyboard`, `controller_one`, and `controller_two`.
+You can access all triggered keys through `truthy_keys` on `keyboard`, `controller_one`, and `controller_two`.
 
 This is how you would right all keys to a file. The game must be in the foreground and have focus for this data
 to be recorded.

--- a/deploy_template/mygame/documentation/99-todo.md
+++ b/deploy_template/mygame/documentation/99-todo.md
@@ -1,12 +1,12 @@
 # Documentation That Needs to be Organized
 
-## Class macro gtk_args
+## Class macro attr_gtk
 
-Here's how you can use the `gtk_args` class method:
+Use the `attr_gtk` class method to help access the different variables provided via `args`:
 
 ```ruby
 class Game
-  gtk_args
+  attr_gtk
   attr_accessor :current_scene, :other_custom_attrs
 
   def tick


### PR DESCRIPTION
- Update `99-todo.md` to use `attr_gtk`
- Fix documentation typos across a few files

There's no [contributing guidelines](https://github.blog/2012-09-17-contributing-guidelines/) for this project, so let me know if you want me to squash these commits for merge.