### PR TITLE
Resolve small typo in 06-keyboard.md

### DIFF
--- a/deploy_template/mygame/documentation/06-keyboard.md
+++ b/deploy_template/mygame/documentation/06-keyboard.md
@@ -55,7 +55,7 @@ end
 
 # List of keys:
 
-These are the character and associated properities that will
+These are the character and associated properties that will
 be set to true.
 
 For example `A => :a, :shift` means that `args.inputs.keyboard.a`


### PR DESCRIPTION
Updated `properities` to `properties`