### PR TITLE
Adding ruby format in Markdown files

### DIFF
--- a/deploy_template/CHEATSHEET.md
+++ b/deploy_template/CHEATSHEET.md
@@ -226,7 +226,7 @@ end
 Returns true if a numeric value plus an offset represents a point
 in time that has elapsed. This is related to args.state.tick_count.
 
-```
+```ruby
 args.state.attacked_at ||= args.state.tick_count
 puts args.state.attacked_at.elapsed? 60  # will print false after one second.
 ```

--- a/deploy_template/mygame/documentation/05-sprites.md
+++ b/deploy_template/mygame/documentation/05-sprites.md
@@ -185,7 +185,7 @@ args.outputs.sprites << {
   h: 100,
   path: "sprites/player.png",
   angle: 0,
-  a, 255
+  a: 255
   r: 255,
   g: 255,
   b: 255,

--- a/deploy_template/mygame/documentation/06-keyboard.md
+++ b/deploy_template/mygame/documentation/06-keyboard.md
@@ -2,7 +2,7 @@
 
 Determining if `a` key is in the down state (pressed). This happens once each time the key is pressed:
 
-```
+```ruby
 if args.inputs.keyboard.key_down.a
   puts 'The key is pressed'
 end
@@ -10,7 +10,7 @@ end
 
 Determining if a key is being held. This happens every tick while the key is held down:
 
-```
+```ruby
 if args.inputs.keyboard.key_held.a
   puts 'The key is being held'
 end
@@ -18,7 +18,7 @@ end
 
 Determining if a key is in the down state or is being held:
 
-```
+```ruby
 if args.inputs.keyboard.a
   puts 'The key is pressed or being held'
 end
@@ -26,7 +26,7 @@ end
 
 Determining if a key is in the up state (released). This happens once each time the key is released:
 
-```
+```ruby
 if args.inputs.keyboard.key_up.a
   puts 'The key is released'
 end
@@ -39,7 +39,7 @@ You can access all triggered keys through `truthy_keys` on `keyboard`, `controll
 This is how you would right all keys to a file. The game must be in the foreground and have focus for this data
 to be recorded.
 
-```
+```ruby
 def tick args
     [
     [args.inputs.keyboard,       :keyboard],

--- a/deploy_template/mygame/documentation/07-mouse.md
+++ b/deploy_template/mygame/documentation/07-mouse.md
@@ -2,7 +2,7 @@
 
 Determining current position of mouse:
 
-```
+```ruby
 args.inputs.mouse.x
 args.inputs.mouse.y
 ```
@@ -10,7 +10,7 @@ args.inputs.mouse.y
 Determining if the mouse has been clicked, and it's position. Note:
 `click` and `down` are aliases for each other.
 
-```
+```ruby
 if args.inputs.mouse.click
   puts "click: #{args.inputs.mouse.click}"
   puts "x: #{args.inputs.mouse.click.point.x}"
@@ -20,7 +20,7 @@ end
 
 Determining if the mouse button has been released:
 
-```
+```ruby
 if args.inputs.mouse.up
   puts "up: #{args.inputs.mouse.up}"
   puts "x: #{args.inputs.mouse.up.point.x}"
@@ -29,7 +29,8 @@ end
 ```
 
 Determine which mouse button(s) have been clicked (also works for up):
-```
+
+```ruby
 if args.inputs.mouse.click
   puts "left: #{args.inputs.mouse.button_left}"
   puts "middle: #{args.inputs.mouse.button_middle}"
@@ -40,7 +41,8 @@ end
 ```
 
 Determine if the mouse wheel is being used and its values for this tick:
-```
+
+```ruby
 if args.inputs.mouse.wheel
   puts "The wheel moved #{args.inputs.mouse.wheel.x} left/right"
   puts "The wheel moved #{args.inputs.mouse.wheel.y} up/down"

--- a/deploy_template/mygame/documentation/08-controllers.md
+++ b/deploy_template/mygame/documentation/08-controllers.md
@@ -2,14 +2,14 @@
 
 There are two controllers you have access to:
 
-```
+```ruby
 args.inputs.controller_one
 args.inputs.controller_two
 ```
 
 Determining if a key was down:
 
-```
+```ruby
 if args.inputs.controller_one.key_down.a
   puts 'The key was in the down state'
 end
@@ -17,7 +17,7 @@ end
 
 Determining if a key is being held:
 
-```
+```ruby
 if args.inputs.controller_one.key_held.a
   puts 'The key is being held'
 end
@@ -25,7 +25,7 @@ end
 
 Determining if a key is released:
 
-```
+```ruby
 if args.inputs.controller_one.key_up.a
   puts 'The key is being held'
 end
@@ -38,7 +38,7 @@ You can access all triggered keys through `thruthy_keys` on `keyboard`, `control
 This is how you would right all keys to a file. The game must be in the foreground and have focus for this data
 to be recorded.
 
-```
+```ruby
 def tick args
     [
     [args.inputs.keyboard,       :keyboard],


### PR DESCRIPTION
Small change, but it will make code looks [prettier in Github](https://github.com/alagos/dragonruby-game-toolkit-contrib/blob/c1a5335274dfdf59d12892d2f5e967209f208b1c/deploy_template/mygame/documentation/06-keyboard.md) or any other Markdown viewer.