### PR TITLE
Compares console output using Symbol equality

### DIFF
--- a/dragon/console.rb
+++ b/dragon/console.rb
@@ -478,7 +478,7 @@ S
             Kernel.eval("$results = (#{cmd})")
             if $results.nil?
               puts "=> nil"
-            elsif $results == :console_silent_eval
+            elsif :console_silent_eval == $results
             else
               puts "=> #{$results}"
             end


### PR DESCRIPTION
When evaluating a command in the console that results in an object with a custom equality method, this line would previously assume the object to compare nicely with a symbol. This change forces the use of the equality method on the symbol instead, making it harder for a custom object to mess up the console.

Current behavior:
```Ruby
-> (class A; def initialize; end; def ==(other); other.some_non_symbol_method; end; end; A).new
* ERROR:
** method_missing: some_non_symbol_method
** instance:       console_silent_eval
** on class:       Symbol
** with modules:   [ValueType, Comparable, Kernel]
** with values:    console_silent_eval
** given args:     [[]]
** exception:      can't define singleton
```

Behavior when compared with the symbol first:
```Ruby
-> :a_symbol == (class A; def initialize; end; def ==(other); other.some_non_symbol_method; end; end; A).new
=> false
```