### PR TITLE
Allows editing old history commands

### DIFF
--- a/dragon/console.rb
+++ b/dragon/console.rb
@@ -589,7 +589,7 @@ S
         end
         if @command_history_index < (@command_history.length - 1)
           @command_history_index += 1
-          self.current_input_str = @command_history[@command_history_index].clone
+          self.current_input_str = @command_history[@command_history_index].dup
         end
       elsif args.inputs.keyboard.key_down.down
         if @command_history_index == 0
@@ -598,7 +598,7 @@ S
           @nonhistory_input = ''
         elsif @command_history_index > 0
           @command_history_index -= 1
-          self.current_input_str = @command_history[@command_history_index].clone
+          self.current_input_str = @command_history[@command_history_index].dup
         end
       elsif inputs_scroll_up_full? args
         scroll_up_full


### PR DESCRIPTION
Trying to edit an old history command would previously crash the console with the following error:
```
can't modify frozen string
* FATAL: The GTK::Console console threw an unhandled exception and has been reset. You should report this exception (along with reproduction steps) to DragonRuby.
```

This only seems to happen for history commands that were loaded from file. While I am not sure of the exact inner workings of `ffi_file`, I do know that `clone` retains `frozen` status, while `dup` clears it. This should fix the above error.