### PR TITLE
iOS wizard: fix app id in Info.plist, fix dev profile path

### DIFF
--- a/dragon/ios_wizard.rb
+++ b/dragon/ios_wizard.rb
@@ -538,7 +538,10 @@ XML
     # <string>UIInterfaceOrientationPortrait</string>
     # <string>UIInterfaceOrientationLandscapeRight</string>
 
-    $gtk.write_file_root "tmp/ios/#{@app_name}.app/Info.plist", info_plist_string.gsub(":app_name", @app_name).strip
+    info_plist_string.gsub!(":app_name", @app_name)
+    info_plist_string.gsub!(":app_id", @app_id)
+
+    $gtk.write_file_root "tmp/ios/#{@app_name}.app/Info.plist", info_plist_string.strip
 
     @info_plist_written = true
   end

--- a/dragon/ios_wizard.rb
+++ b/dragon/ios_wizard.rb
@@ -140,7 +140,8 @@ class IOSWizard
   end
 
   def check_for_dev_profile
-    if !($gtk.read_file 'profiles/development.mobileprovision')
+    @dev_profile_path = "profiles/development.mobileprovision"
+    if !($gtk.read_file @dev_profile_path)
       $gtk.system "mkdir -p #{relative_path}/profiles"
       $gtk.system "open #{relative_path}/profiles"
       $gtk.system "echo Download the mobile provisioning profile and place it here with the name development.mobileprovision > #{relative_path}/profiles/README.txt"
@@ -409,7 +410,7 @@ XML
 		</dict>
 	</dict>
 	<key>CFBundleIdentifier</key>
-	<string>com.carlile.swisscheese</string>
+	<string>:app_id</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>


### PR DESCRIPTION
Fixes the issue I was seeing with multiple iOS apps:

```
Error when install package on device: code -402620394
The executable was signed with invalid entitlements.
```

Also fixes the `cp` command in `#code_sign` for `embedded.mobileprovision`