### PR TITLE
Fixed parameter description typo in solids sample

### DIFF
--- a/samples/01_rendering_basics/03_solids_borders/app/main.rb
+++ b/samples/01_rendering_basics/03_solids_borders/app/main.rb
@@ -15,7 +15,7 @@ APIs listing that haven't been encountered in a previous sample apps:
 # Borders are added to args.outputs.borders
 
 # The parameters required for rects are:
-# 1. The upper right corner (x, y)
+# 1. The bottom left corner (x, y)
 # 2. The width (w)
 # 3. The height (h)
 # 4. The rgba values for the color and transparency (r, g, b, a)


### PR DESCRIPTION
I found a small typo in the `solids_borders` sample that stated the x and y coordinates of a rectangle related to the upper right corner of the rectangle. After playing around, I believe that the x and y coordinates relate to the bottom left corner of the rectangle. Please let me know if I misinterpreted this documentation or need to make any changes. Thank you!