### PR TITLE
When scrolling (up/down arrow) through console history, move cursor to end of line #53

### DIFF
--- a/dragon/console.rb
+++ b/dragon/console.rb
@@ -448,6 +448,7 @@ S
           @command_history_index += 1
           self.current_input_str = @command_history[@command_history_index].dup
         end
+        prompt.move_cursor_end
       elsif args.inputs.keyboard.key_down.down
         if @command_history_index == 0
           @command_history_index = -1
@@ -457,6 +458,7 @@ S
           @command_history_index -= 1
           self.current_input_str = @command_history[@command_history_index].dup
         end
+        prompt.move_cursor_end
       elsif args.inputs.keyboard.key_down.left
         if args.inputs.keyboard.key_down.control
           prompt.move_cursor_left_word


### PR DESCRIPTION
-Remade PR because I was submitting another one and make a mess out of my local git-

My OCD was getting triggered by cursor staying static/jumping when scrolling through commands with up/down arrows in console. So now when scrolling up/down, we move the cursor to the end as normally happens in bash/terminals.

Also, without requiring the `console_prompt` from this repo, Prompt only has `move_cursor_left/right` - so I guess something is out of sync? 

![image](https://user-images.githubusercontent.com/4464899/104794375-87892880-57a7-11eb-861c-d69f7614f83d.png)
