### PR TITLE
Fix order of tile_* and flip_* arguments for draw_sprite_3 example

### DIFF
--- a/samples/09_performance/06_static_sprites_as_classes_with_custom_drawing/app/main.rb
+++ b/samples/09_performance/06_static_sprites_as_classes_with_custom_drawing/app/main.rb
@@ -39,9 +39,9 @@ class Star
     # x, y, w, h,
     # path,
     # angle,
-    # alpha, red_saturation, green_saturation, blue_saturation
+    # alpha, red_saturation, green_saturation, blue_saturation,
+    # tile_x, tile_y, tile_w, tile_h,
     # flip_horizontally, flip_vertically,
-    # tile_x, tile_y, tile_w, tile_h
     # angle_anchor_x, angle_anchor_y,
     # source_x, source_y, source_w, source_h
   end


### PR DESCRIPTION
Thanks to @HIRO-R-B for pointing this out:
https://discord.com/channels/608064116111966245/759126199854301215/800212483117285376