### PR TITLE
Make it easier to rearrange draw order

### DIFF
--- a/dragon/draw.rb
+++ b/dragon/draw.rb
@@ -1,3 +1,4 @@
+# Contributors outside of DragonRuby who also hold Copyright: Nick Sandberg
 # Copyright 2019 DragonRuby LLC
 # MIT License
 # draw.rb has been released under MIT (*only this file*).
@@ -5,110 +6,30 @@
 module GTK
   class Runtime
     module Draw
+
+      def execute_draw_order pass
+        # Don't change this draw order unless you understand
+        # the implications.
+        render_static_sprites pass
+        render_solids pass
+        render_sprites pass
+        render_static_solids pass
+        render_primitives pass
+        render_static_primitives pass
+        render_labels pass
+        render_static_labels pass
+        render_lines pass
+        render_static_lines pass
+        render_borders pass
+        render_static_borders pass
+      end
+
       def primitives pass
         if $top_level.respond_to? :primitives_override
           return $top_level.tick_render @args, pass
         end
 
-        # Don't change this draw order unless you understand
-        # the implications.
-
-        # pass.solids.each            { |s| draw_solid s }
-        # while loops are faster than each with block
-        idx = 0
-        length = pass.solids.length
-        while idx < pass.solids.length
-          draw_solid (pass.solids.at idx) # accessing an array using .value instead of [] is faster
-          idx += 1
-        end
-
-        # pass.static_solids.each     { |s| draw_solid s }
-        idx = 0
-        length = pass.static_solids.length
-        while idx < length
-          draw_solid (pass.static_solids.at idx)
-          idx += 1
-        end
-
-        # pass.sprites.each           { |s| draw_sprite s }
-        idx = 0
-        length = pass.sprites.length
-        while idx < length
-          draw_sprite (pass.sprites.at idx)
-          idx += 1
-        end
-
-        # pass.static_sprites.each    { |s| draw_sprite s }
-        idx = 0
-        length = pass.static_sprites.length
-        while idx < length
-          draw_sprite (pass.static_sprites.at idx)
-          idx += 1
-        end
-
-        # pass.primitives.each        { |p| draw_primitive p }
-        idx = 0
-        length = pass.primitives.length
-        while idx < length
-          draw_primitive (pass.primitives.at idx)
-          idx += 1
-        end
-
-        # pass.static_primitives.each { |p| draw_primitive p }
-        idx = 0
-        length = pass.static_primitives.length
-        while idx < length
-          draw_primitive (pass.static_primitives.at idx)
-          idx += 1
-        end
-
-        # pass.labels.each            { |l| draw_label l }
-        idx = 0
-        length = pass.labels.length
-        while idx < length
-          draw_label (pass.labels.at idx)
-          idx += 1
-        end
-
-        # pass.static_labels.each     { |l| draw_label l }
-        idx = 0
-        length = pass.static_labels.length
-        while idx < length
-          draw_label (pass.static_labels.at idx)
-          idx += 1
-        end
-
-        # pass.lines.each             { |l| draw_line l }
-        idx = 0
-        length = pass.lines.length
-        while idx < length
-          draw_line (pass.lines.at idx)
-          idx += 1
-        end
-
-        # pass.static_lines.each      { |l| draw_line l }
-        idx = 0
-        length = pass.static_lines.length
-        while idx < pass.static_lines.length
-          draw_line (pass.static_lines.at idx)
-          idx += 1
-        end
-
-        # pass.borders.each           { |b| draw_border b }
-        idx = 0
-        length = pass.borders.length
-        while idx < length
-          draw_border (pass.borders.at idx)
-          idx += 1
-        end
-
-        # pass.static_borders.each    { |b| draw_border b }
-        idx = 0
-        length = pass.static_borders.length
-        while idx < length
-          draw_border (pass.static_borders.at idx)
-          idx += 1
-        end
+        execute_draw_order pass
 
         if !$gtk.production
           # pass.debug.each        { |r| draw_primitive r }
@@ -146,6 +67,128 @@ module GTK
       rescue Exception => e
         pause!
         pretty_print_exception_and_export! e
+      end
+
+
+      def render_solids pass
+        # pass.solids.each            { |s| draw_solid s }
+        # while loops are faster than each with block
+        idx = 0
+        length = pass.solids.length
+        while idx < pass.solids.length
+          draw_solid (pass.solids.at idx) # accessing an array using .value instead of [] is faster
+          idx += 1
+        end
+      end
+
+      def render_static_solids pass
+        # pass.static_solids.each     { |s| draw_solid s }
+        idx = 0
+        length = pass.static_solids.length
+        while idx < length
+          draw_solid (pass.static_solids.at idx)
+          idx += 1
+        end
+      end
+
+      def render_sprites pass
+        # pass.sprites.each           { |s| draw_sprite s }
+        idx = 0
+        length = pass.sprites.length
+        while idx < length
+          draw_sprite (pass.sprites.at idx)
+          idx += 1
+        end
+      end
+
+      def render_static_sprites pass
+        # pass.static_sprites.each    { |s| draw_sprite s }
+        idx = 0
+        length = pass.static_sprites.length
+        while idx < length
+          draw_sprite (pass.static_sprites.at idx)
+          idx += 1
+        end
+      end
+
+      def render_primitives pass
+        # pass.primitives.each        { |p| draw_primitive p }
+        idx = 0
+        length = pass.primitives.length
+        while idx < length
+          draw_primitive (pass.primitives.at idx)
+          idx += 1
+        end
+      end
+
+      def render_static_primitives pass
+        # pass.static_primitives.each { |p| draw_primitive p }
+        idx = 0
+        length = pass.static_primitives.length
+        while idx < length
+          draw_primitive (pass.static_primitives.at idx)
+          idx += 1
+        end
+      end
+
+      def render_labels pass
+        # pass.labels.each            { |l| draw_label l }
+        idx = 0
+        length = pass.labels.length
+        while idx < length
+          draw_label (pass.labels.at idx)
+          idx += 1
+        end
+      end
+
+      def render_static_labels pass
+        # pass.static_labels.each     { |l| draw_label l }
+        idx = 0
+        length = pass.static_labels.length
+        while idx < length
+          draw_label (pass.static_labels.at idx)
+          idx += 1
+        end
+      end
+
+      def render_lines pass
+        # pass.lines.each             { |l| draw_line l }
+        idx = 0
+        length = pass.lines.length
+        while idx < length
+          draw_line (pass.lines.at idx)
+          idx += 1
+        end
+      end
+      
+      def render_static_lines pass
+        # pass.static_lines.each      { |l| draw_line l }
+        idx = 0
+        length = pass.static_lines.length
+        while idx < pass.static_lines.length
+          draw_line (pass.static_lines.at idx)
+          idx += 1
+        end
+      end
+
+      def render_borders pass
+        # pass.borders.each           { |b| draw_border b }
+        idx = 0
+        length = pass.borders.length
+        while idx < length
+          draw_border (pass.borders.at idx)
+          idx += 1
+        end
+      end
+
+      def render_static_borders pass
+        # pass.static_borders.each    { |b| draw_border b }
+        idx = 0
+        length = pass.static_borders.length
+        while idx < length
+          draw_border (pass.static_borders.at idx)
+          idx += 1
+        end
       end
 
       def draw_solid s

--- a/dragon/draw.rb
+++ b/dragon/draw.rb
@@ -10,10 +10,10 @@ module GTK
       def execute_draw_order pass
         # Don't change this draw order unless you understand
         # the implications.
-        render_static_sprites pass
         render_solids pass
-        render_sprites pass
         render_static_solids pass
+        render_sprites pass
+        render_static_sprites pass
         render_primitives pass
         render_static_primitives pass
         render_labels pass


### PR DESCRIPTION
After having a conversation on the Discord channel I decided not to go this route to change my rendering sequence because I was concerned about changes to draw.rb breaking functionality in the future and then being stuck with maintaining the monkeypatch. After the conversation I decided to try to attempt a way so that the user could redefine only the execute_draw_order method which is clearer and also allows for changes to the render_* methods implementations fairly easily.

Caveat: I have not speed tested or stress tested this. I have only tested it on my local machine.