### PR TITLE
iOS wizard: set version in prod builds

### DIFF
--- a/dragon/ios_wizard.rb
+++ b/dragon/ios_wizard.rb
@@ -84,8 +84,8 @@ class IOSWizard
     sprite_path
   end
 
-  def start opts = nil
-    @opts = opts || {}
+  def start opts = {}
+    @opts = opts
 
     unless $gtk.args.fn.eq_any? @opts[:env], :dev, :prod
       raise WizardException.new(
@@ -104,7 +104,11 @@ class IOSWizard
     @steps = steps_production_build if @production_build
     @certificate_name = nil
     init_wizard_status
-    log_info "Starting iOS Wizard so we can deploy to your device."
+    if @production_build
+      log_info "Starting iOS Wizard so we can create a production build."
+    else
+      log_info "Starting iOS Wizard so we can deploy to your device."
+    end
     @start_at = Kernel.global_tick_count
     steps.each do |m|
       log_info "Running step ~:#{m}~."

--- a/dragon/itch_wizard.rb
+++ b/dragon/itch_wizard.rb
@@ -3,46 +3,13 @@
 # itch_wizard.rb has been released under MIT (*only this file*).
 
 class ItchWizard
+  include Metadata
+
   def steps
     [
       :check_metadata,
       :deploy
     ]
-  end
-
-  def metadata_file_path
-    "metadata/game_metadata.txt"
-  end
-
-  def get_metadata
-    metadata = $gtk.read_file metadata_file_path
-
-    if !metadata
-      write_blank_metadata
-      metadata = $gtk.read_file metadata_file_path
-    end
-
-    dev_id, dev_title, game_id, game_title, version, icon = *metadata.each_line.to_a
-
-    {
-      dev_id: dev_id.strip,
-      dev_title: dev_title.strip,
-      game_id: game_id.strip,
-      game_title: game_title.strip,
-      version: version.strip,
-      icon: icon.strip
-    }
-  end
-
-  def write_blank_metadata
-      $gtk.write_file metadata_file_path, <<-S.strip
-#devid=myname
-#devtitle=My Name
-#gameid=mygame
-#gametitle=My Game
-#version=0.1
-#icon=metadata/icon.png
-S
   end
 
   def check_metadata

--- a/dragon/metadata.rb
+++ b/dragon/metadata.rb
@@ -1,0 +1,41 @@
+# Contributors outside of DragonRuby who also hold Copyright: Michał Dudziński
+# Copyright 2021 DragonRuby LLC
+# MIT License
+# metadata.rb has been released under MIT (*only this file*).
+
+module Metadata
+  def metadata_file_path
+    "metadata/game_metadata.txt"
+  end
+
+  def get_metadata
+    metadata = $gtk.read_file metadata_file_path
+
+    if !metadata
+      write_blank_metadata
+      metadata = $gtk.read_file metadata_file_path
+    end
+
+    dev_id, dev_title, game_id, game_title, version, icon = *metadata.each_line.to_a
+
+    {
+      dev_id: dev_id.strip,
+      dev_title: dev_title.strip,
+      game_id: game_id.strip,
+      game_title: game_title.strip,
+      version: version.strip,
+      icon: icon.strip
+    }
+  end
+
+  def write_blank_metadata
+      $gtk.write_file metadata_file_path, <<-S.strip
+#devid=myname
+#devtitle=My Name
+#gameid=mygame
+#gametitle=My Game
+#version=0.1
+#icon=metadata/icon.png
+S
+  end
+end


### PR DESCRIPTION
The version can be set either via the `version` param in the `opts` hash or the metadata file.
The wizard will look for the version number in the `opts` hash first, then in the metadata file and fall back to just `'1.0'` if needed.

The param approach:
```
$wizards.ios.start env: :prod, version: 1.0
```

Feel free to suggest either a better variable naming (I was considering `build_number` instead of `version`) or an instructions wording.