### PR TITLE
Add back prism syntax highlighting

### DIFF
--- a/dragon/docs.rb
+++ b/dragon/docs.rb
@@ -257,8 +257,8 @@ S
   <head>
     <title>DragonRuby Game Toolkit Documentation</title>
     <link href="docs.css?ver=#{Time.now.to_i}" rel="stylesheet" type="text/css" media="all">
+    <link href="prism.css" rel="stylesheet" />
   </head>
-  <body>
     <div id='toc'>
 S
     html_toc_end_to_content_start = <<-S
@@ -267,6 +267,37 @@ S
 S
     html_content_end_to_html_end = <<-S
     </div>
+    <script src="prism.js" data-manual></script>
+    <script>
+      document.addEventListener("DOMContentLoaded", function() {
+              var lazyloadElements = document.querySelectorAll("code");
+              var lazyloadThrottleTimeout;
+
+              function lazyload () {
+                      if(lazyloadThrottleTimeout) {
+                              clearTimeout(lazyloadThrottleTimeout);
+                            }
+
+                      lazyloadThrottleTimeout = setTimeout(function() {
+                              var scrollTop = window.pageYOffset;
+                              lazyloadElements.forEach(function(elem) {
+                                      if(elem.offsetTop < (window.innerHeight + scrollTop)) {
+                                              Prism.highlightElement(elem);
+                                            }
+                                    });
+                              if(lazyloadElements.length == 0) {
+                                      document.removeEventListener("scroll", lazyload);
+                                      window.removeEventListener("resize", lazyload);
+                                      window.removeEventListener("orientationChange", lazyload);
+                                    }
+                            }, 20);
+                    }
+
+              document.addEventListener("scroll", lazyload);
+              window.addEventListener("resize", lazyload);
+              window.addEventListener("orientationChange", lazyload);
+            });
+    </script>
   </body>
 </html>
 S

--- a/dragon/docs.rb
+++ b/dragon/docs.rb
@@ -259,6 +259,7 @@ S
     <link href="docs.css?ver=#{Time.now.to_i}" rel="stylesheet" type="text/css" media="all">
     <link href="prism.css" rel="stylesheet" />
   </head>
+  <body class="language-ruby">
     <div id='toc'>
 S
     html_toc_end_to_content_start = <<-S

--- a/dragon/docs.rb
+++ b/dragon/docs.rb
@@ -2,6 +2,8 @@
 # Copyright 2019 DragonRuby LLC
 # MIT License
 # docs.rb has been released under MIT (*only this file*).
+# Contributors outside of DragonRuby who also hold Copyright:
+# - Jeff Schoolcraft: https://github.com/jschoolcraft
 
 module DocsOrganizer
   def self.sort_docs_classes!

--- a/dragon/docs.rb
+++ b/dragon/docs.rb
@@ -272,34 +272,15 @@ S
     </div>
     <script src="prism.js" data-manual></script>
     <script>
+      highlight = function() {
+        document.querySelectorAll('pre>code').forEach(function(elem, index) {
+          Prism.highlightElement(elem);
+        })
+      }
+
       document.addEventListener("DOMContentLoaded", function() {
-              var lazyloadElements = document.querySelectorAll("pre>code");
-              var lazyloadThrottleTimeout;
-
-              function lazyload () {
-                      if(lazyloadThrottleTimeout) {
-                              clearTimeout(lazyloadThrottleTimeout);
-                            }
-
-                      lazyloadThrottleTimeout = setTimeout(function() {
-                              var scrollTop = window.pageYOffset;
-                              lazyloadElements.forEach(function(elem) {
-                                      if(elem.offsetTop < (window.innerHeight + scrollTop)) {
-                                              Prism.highlightElement(elem);
-                                            }
-                                    });
-                              if(lazyloadElements.length == 0) {
-                                      document.removeEventListener("scroll", lazyload);
-                                      window.removeEventListener("resize", lazyload);
-                                      window.removeEventListener("orientationChange", lazyload);
-                                    }
-                            }, 20);
-                    }
-
-              document.addEventListener("scroll", lazyload);
-              window.addEventListener("resize", lazyload);
-              window.addEventListener("orientationChange", lazyload);
-            });
+        setTimeout(highlight, 500);
+      });
     </script>
   </body>
 </html>

--- a/dragon/docs.rb
+++ b/dragon/docs.rb
@@ -274,12 +274,12 @@ S
     <script>
       highlight = function() {
         document.querySelectorAll('pre>code').forEach(function(elem, index) {
-          Prism.highlightElement(elem);
+          setTimeout(Prism.highlightElement, index * 50, elem);
         })
       }
 
       document.addEventListener("DOMContentLoaded", function() {
-        setTimeout(highlight, 500);
+        setTimeout(highlight, 250);
       });
     </script>
   </body>

--- a/dragon/docs.rb
+++ b/dragon/docs.rb
@@ -261,7 +261,7 @@ S
     <link href="docs.css?ver=#{Time.now.to_i}" rel="stylesheet" type="text/css" media="all">
     <link href="prism.css" rel="stylesheet" />
   </head>
-  <body class="language-ruby">
+  <body>
     <div id='toc'>
 S
     html_toc_end_to_content_start = <<-S

--- a/dragon/docs.rb
+++ b/dragon/docs.rb
@@ -273,7 +273,7 @@ S
     <script src="prism.js" data-manual></script>
     <script>
       document.addEventListener("DOMContentLoaded", function() {
-              var lazyloadElements = document.querySelectorAll("code");
+              var lazyloadElements = document.querySelectorAll("pre>code");
               var lazyloadThrottleTimeout;
 
               function lazyload () {

--- a/dragon/docs.rb
+++ b/dragon/docs.rb
@@ -274,7 +274,7 @@ S
     <script>
       highlight = function() {
         document.querySelectorAll('pre>code').forEach(function(elem, index) {
-          setTimeout(Prism.highlightElement, index * 50, elem);
+          Prism.highlightElement(elem);
         })
       }
 


### PR DESCRIPTION
This PR adds back both the stylesheet and `prism.js`.  It also uses Language Inheritance to set the global language to `ruby`.

`prism.js` script block has the `data-manual` attribute to prevent any elements from being automatically highlighted.

The current approach is to wait 250ms after `DOMContentLoaded` then iterate over all `pre>code` elements and call `Prism.highlightElement()`

Here's what it looks like after exporting (all on mac):  

Brave:

https://user-images.githubusercontent.com/18264/114874956-d5272880-9dca-11eb-9bfb-5ed16bbec49f.mp4

This version is still Brave, I only wanted to show that it's not blocking the UI so you can still start scrolling/searching and highlighting will just happen eventually:

https://user-images.githubusercontent.com/18264/114875891-c0976000-9dcb-11eb-94cd-58c5bd17474a.mp4

Safari:

https://user-images.githubusercontent.com/18264/114875125-fab43200-9dca-11eb-8dfb-170e351974f0.mp4

Firefox:

https://user-images.githubusercontent.com/18264/114875259-1f100e80-9dcb-11eb-8835-e41d6e359ed9.mp4

Chrome:

https://user-images.githubusercontent.com/18264/114875532-60082300-9dcb-11eb-95de-df4010652a9f.mp4
