### PR TITLE
Updating documentation on repl logging to logs/puts.txt

### DIFF
--- a/dragon/readme_docs.rb
+++ b/dragon/readme_docs.rb
@@ -1109,7 +1109,7 @@ file called ~repl.rb~ and put it in ~mygame/app/repl.rb~:
 
 - If you use the `repl` method, the code will be executed and the DragonRuby Console will automatically open so you can see the results (on Mac and Linux, the results will also be printed to the terminal).
 
-- All ~puts~ statements will also be saved to ~logs/log.txt~. So if you want to stay in your editor and not look at the terminal, or the DragonRuby Console, you can ~tail~ this file.
+- All ~puts~ statements will also be saved to ~logs/puts.txt~. So if you want to stay in your editor and not look at the terminal, or the DragonRuby Console, you can ~tail~ this file.
 
 4. To ignore code in ~repl.rb~, instead of commenting it out, prefix ~repl~ with the letter ~x~ and it'll be ignored.
 


### PR DESCRIPTION
Simple documentation change for: 
https://stackoverflow.com/questions/67696713/puts-statements-in-repl-rb-are-not-printed-to-logs-log-txt

> While going through the dragon ruby documentation here: http://docs.dragonruby.org. It says
> 
> "All puts statements will also be saved to logs/log.txt. So if you want to stay in your editor and not look at the terminal, or the DragonRuby Console, you can tail this file."
> However when I write puts statements, this is the output in logs
> 
> INFO: Marked app/repl.rb for reload