### PR TITLE
Add support for rubydocs.info

### DIFF
--- a/.yardopts
+++ b/.yardopts
@@ -1,0 +1,1 @@
+dragon/*.rb


### PR DESCRIPTION
I added a .yardopts file so YARD (https://yardoc.org/) can inspect the.rb  files in /dragon and make pretty API documentation out of them for those of us that like that sort of thing. You can see it in action here: https://rubydoc.info/github/ajbdev/dragonruby-game-toolkit-contrib

I figured I'd PR this back in case this is something you'd want. Cheers!