### PR TITLE
docs: Update sprite class example with attr_sprite

### DIFF
--- a/docs/todo/05-sprites.md
+++ b/docs/todo/05-sprites.md
@@ -179,26 +179,14 @@ args.outputs.sprites << {
 
 ## Duck Typing (Advanced)
 
-You can also create a class with sprite properties and render it as a primitive.
-ALL properties must on the class. ADDITIONALLY, a method called `primitive_marker`
-must be defined on the class.
+You can also create a class with sprite properties and render it as a primitive,
+using the `attr_sprite` helper.
 
 Here is an example:
 
 ```ruby
-# Create type with ALL sprite properties AND primitive_marker
-class Sprite
-  attr_accessor :x, :y, :w, :h, :path, :angle, :a, :r, :g, :b, :source_x,
-                :source_y, :source_w, :source_h, :flip_horizontally,
-                :flip_vertically, :angle_anchor_x, :angle_anchor_y
-
-  def primitive_marker
-    :sprite
-  end
-end
-
-# Inherit from type
-class PlayerSprite < Sprite
+class PlayerSprite
+  attr_sprite
 
   # constructor
   def initialize x, y, w, h


### PR DESCRIPTION
### Context

While browsing the docs in this directory, I copied the example to create a sprite class with all the attributes.

It failed due to some missing params (tile_x, tile_y)?

later on browsing the sprite examples I found the `attr_sprite` helper, which seems a more convenient and future proof method of doing this.

### Change

Update example to use `attr_sprite` rather than list out the individual sprite attributes.