### PR TITLE
fix: Tests logging incorrect message

### DIFF
--- a/dragon/tests.rb
+++ b/dragon/tests.rb
@@ -3,6 +3,9 @@
 # MIT License
 # tests.rb has been released under MIT (*only this file*).
 
+# Contributors outside of DragonRuby who also hold Copyright:
+# - Eli Raybon: https://github.com/eliraybon
+
 module GTK
   class Tests
     attr_accessor :failed, :passed, :inconclusive
@@ -96,7 +99,8 @@ S
     end
 
     def test_signature_invalid_exception? e, m
-      e.to_s.include?(m.to_s) && e.to_s.include?("wrong number of arguments")
+      error_message = "'#{m.to_s}': wrong number of arguments"
+      e.to_s.start_with?(error_message)
     end
 
     def log_test_signature_incorrect m


### PR DESCRIPTION
This PR addresses the issue described in: #102 

When a method inside a test fails because it is given the wrong number of arguments, the full error message looks something like this: 
```
'initialize': wrong number of arguments (0 for 1)
* ERROR: Invocation of BadObject.new failed.
** BACKTRACE:
app/tests/tests.rb:4:in test_stuff
app/dragonruby-game-toolkit-contrib-master/dragon/tests.rb:21:in run_test
app/dragonruby-game-toolkit-contrib-master/dragon/tests.rb:56:in start
app/dragonruby-game-toolkit-contrib-master/dragon/tests.rb:56:in start
```

Because this message contains the the method title of the test (`test_stuff`) and `wrong number of arguments`, the message that explains how the signature for a test should look is logged when it shouldn't be. 

My fix checks to make sure the error message starts with the exact error you get when the test method has an invalid signature, which is this: 
```
'method_title': wrong number of arguments
```

It leaves off the argument counts since that part of the message could be (2 for 0) or (2 for 1), depending on how the test method is called. 

Now, the error message is logged if you call `test_stuff args` or `test stuff`... but not when another method in the test is give the wrong number of arguments. 

Hope this makes sense! 
Thanks.