### PR TITLE
Add `scene!` method to allow for render targets of various sizes

### DIFF
--- a/dragon/tweetcart.rb
+++ b/dragon/tweetcart.rb
@@ -8,8 +8,18 @@ def $top_level.TICK &block
     args.outputs[:scene].w = 160
     args.outputs[:scene].h = 90
     args.outputs[:scene].background_color = [0, 0, 0, 0]
+    $args.state.tweet_scene ||= { x: 0, y: 0, w: 1280, h: 720, path: :scene }
     block.call args
-    args.outputs.sprites << { x: 0, y: 0, w: 1280, h: 720, path: :scene }
+    args.outputs.sprites << $args.state.tweet_scene
+  end
+  
+  def $top_level.scene! w = 1280, h = 720
+    $args.outputs[:scene].w = w
+    $args.outputs[:scene].h = h
+    $args.state.tweet_scene.w = w
+    $args.state.tweet_scene.h = h
+    $args.state.tweet_scene.x = ($args.grid.w - w) / 2
+    $args.state.tweet_scene.y = ($args.grid.h - h) / 2
   end
 
   def $top_level.bg! *rgb


### PR DESCRIPTION
User can override the default render target size of 160x90 using
`scene!` # gives default canvas area of 1280x720
or
`scene! w, h` # gives render target new dimensions and outputs at same size with vertical and horizontal centering.

Uses `args.state.tweet_scene` to store output sprite data for the scene render target. Could be a global or some other technique?