### PR TITLE
Fix typo in hotload comments

### DIFF
--- a/dragon/hotload.rb
+++ b/dragon/hotload.rb
@@ -1,7 +1,7 @@
 # coding: utf-8
 # Copyright 2019 DragonRuby LLC
 # MIT License
-# hotlaod.rb has been released under MIT (*only this file*).
+# hotload.rb has been released under MIT (*only this file*).
 
 module GTK
   class Runtime


### PR DESCRIPTION
Fixes a typo in the comments of `hotload.rb` - Fixes issue #69 