### PR TITLE
Remove duplicate attr_accessor

### DIFF
--- a/dragon/console.rb
+++ b/dragon/console.rb
@@ -5,6 +5,7 @@
 
 # Contributors outside of DragonRuby who also hold Copyright:
 # - Kevin Fischer: https://github.com/kfischer-okarin
+# - Eli Raybon: https://github.com/eliraybon
 
 module GTK
   class Console
@@ -12,7 +13,7 @@ module GTK
 
     attr_accessor :show_reason, :log, :logo, :background_color,
                   :text_color, :animation_duration,
-                  :max_log_lines, :max_history, :log,
+                  :max_log_lines, :max_history,
                   :last_command_errored, :last_command, :error_color, :shown_at,
                   :header_color, :archived_log, :last_log_lines, :last_log_lines_count,
                   :suppress_left_arrow_behavior, :command_set_at,


### PR DESCRIPTION
Removes a duplicate attr_accessor mentioned by issue #70 