### PR TITLE
Dev HTTP Server: Fix not found response

### DIFF
--- a/dragon/api.rb
+++ b/dragon/api.rb
@@ -609,6 +609,7 @@ S
         match_found = (process_single! route: route, context: context)
         return if match_found
       end
+      get_not_found context[:args], context[:req]
     end
 
     def process_single! opts

--- a/dragon/api.rb
+++ b/dragon/api.rb
@@ -3,6 +3,9 @@
 # MIT License
 # api.rb has been released under MIT (*only this file*).
 
+# Contributors outside of DragonRuby who also hold Copyright:
+# - Kevin Fischer: https://github.com/kfischer-okarin
+
 module GTK
   class Api
     def initialize


### PR DESCRIPTION
`get_not_found` was defined but not actually used, so when trying to access a non-existing route the browser would just timeout.