### PR TITLE
Dev HTTP Server: Refactor/unify static file handling

### DIFF
--- a/dragon/api.rb
+++ b/dragon/api.rb
@@ -560,7 +560,7 @@ S
         content_type: 'text/plain'
       },
       '/dragon/changes/' => {
-        source: '/tmp/src_backup/src_backup_changes.txt',
+        source: 'tmp/src_backup/src_backup_changes.txt',
         content_type: 'text/plain'
       },
       '/docs.html' => {
@@ -578,23 +578,23 @@ S
         cached: true
       },
       '/src_backup_index.html' => {
-        source: '/tmp/src_backup/src_backup_index.html',
+        source: 'tmp/src_backup/src_backup_index.html',
         content_type: 'text/html'
       },
       '/src_backup_index.txt' => {
-        source: '/tmp/src_backup/src_backup_index.txt',
+        source: 'tmp/src_backup/src_backup_index.txt',
         content_type: 'text/plain'
       },
       '/src_backup_changes.html' => {
-        source: '/tmp/src_backup/src_backup_changes.html',
+        source: 'tmp/src_backup/src_backup_changes.html',
         content_type: 'text/html'
       },
       '/src_backup_changes.txt' => {
-        source: '/tmp/src_backup/src_backup_changes.txt',
+        source: 'tmp/src_backup/src_backup_changes.txt',
         content_type: 'text/plain'
       },
       '/src_backup.css' => {
-        source: '/tmp/src_backup/src_backup.css',
+        source: 'tmp/src_backup/src_backup.css',
         content_type: 'text/css',
         cached: true
       },

--- a/dragon/api.rb
+++ b/dragon/api.rb
@@ -187,18 +187,6 @@ S
                   { 'Content-Type' => 'text/html' }
     end
 
-    def get_api_boot args, req
-      req.respond 200,
-                  args.gtk.read_file("tmp/src_backup/boot.txt"),
-                  { 'Content-Type' => 'text/plain' }
-    end
-
-    def get_api_trace args, req
-      req.respond 200,
-                  args.gtk.read_file("logs/trace.txt"),
-                  { 'Content-Type' => 'text/plain' }
-    end
-
     def get_api_log args, req
       req.respond 200,
                   args.gtk.read_file("logs/log.txt"),
@@ -211,23 +199,6 @@ S
       req.respond 200,
                   "ok",
                   { 'Content-Type' => 'text/plain' }
-    end
-
-    def get_api_puts args, req
-      req.respond 200,
-                  args.gtk.read_file("logs/puts.txt"),
-                  { 'Content-Type' => 'text/plain' }
-    end
-
-    def get_api_changes args, req
-      req.respond 200,
-                  args.gtk.read_file("tmp/src_backup/src_backup_changes.txt"),
-                  { 'Content-Type' => 'text/plain' }
-    end
-
-    def get_favicon_ico args, req
-      @favicon ||= args.gtk.read_file('docs/favicon.ico')
-      req.respond 200, @favicon, { "Content-Type" => 'image/x-icon' }
     end
 
     def get_src_backup args, req
@@ -243,54 +214,6 @@ S
       puts("HEADERS:");
       req.headers.each { |k,v| puts("  #{k}: #{v}") }
       req.respond 404, "not found: #{req.uri}", { }
-    end
-
-    def get_docs_html args, req
-      req.respond 200,
-                  args.gtk.read_file("docs/docs.html"),
-                  { 'Content-Type' => 'text/html' }
-    end
-
-    def get_docs_css args, req
-      req.respond 200,
-                  args.gtk.read_file("docs/docs.css"),
-                  { 'Content-Type' => 'text/css' }
-    end
-
-    def get_docs_search_gif args, req
-      req.respond 200,
-                  args.gtk.read_file("docs/docs_search.gif"),
-                  { 'Content-Type' => 'image/gif' }
-    end
-
-    def get_src_backup_index_html args, req
-      req.respond 200,
-                  args.gtk.read_file("/tmp/src_backup/src_backup_index.html"),
-                  { 'Content-Type' => 'text/html' }
-    end
-
-    def get_src_backup_index_txt args, req
-      req.respond 200,
-                  args.gtk.read_file("/tmp/src_backup/src_backup_index.txt"),
-                  { 'Content-Type' => 'text/txt' }
-    end
-
-    def get_src_backup_css args, req
-      req.respond 200,
-                  args.gtk.read_file("/tmp/src_backup/src_backup.css"),
-                  { 'Content-Type' => 'text/css' }
-    end
-
-    def get_src_backup_changes_html args, req
-      req.respond 200,
-                  args.gtk.read_file("/tmp/src_backup/src_backup_changes.html"),
-                  { 'Content-Type' => 'text/html' }
-    end
-
-    def get_src_backup_changes_txt args, req
-      req.respond 200,
-                  args.gtk.read_file("/tmp/src_backup/src_backup_changes.txt"),
-                  { 'Content-Type' => 'text/txt' }
     end
 
     def get_api_eval args, req
@@ -356,10 +279,6 @@ S
 
       $eval_result  = nil
       $eval_results = nil
-    end
-
-    def api_css_string
-
     end
 
     def get_api_console args, req

--- a/dragon/api.rb
+++ b/dragon/api.rb
@@ -441,7 +441,6 @@ S
          handler:        :get_index },
        { match_criteria: { method: :get, uri: "/dragon/" },
          handler:        :get_index },
-
        { match_criteria: { method: :post, uri: "/dragon/log/" },
          handler:        :post_api_log },
        { match_criteria: { method: :get, uri: "/dragon/eval/" },
@@ -474,11 +473,6 @@ S
          handler:        :get_api_code_edit },
        { match_criteria: { method: :post, uri: "/dragon/code/update/", has_query_string: true },
          handler:        :post_api_code_update },
-
-
-       { match_criteria: { method: :get, end_with_rb: true },
-         handler:        :get_src_backup },
-
        { match_criteria: { method: :get, end_with_rb: true },
          handler:        :get_src_backup },
        *static_file_routes

--- a/dragon/api.rb
+++ b/dragon/api.rb
@@ -523,18 +523,8 @@ S
        { match_criteria: { method: :get, uri: "/dragon/" },
          handler:        :get_index },
 
-       { match_criteria: { method: :get, uri: "/dragon/boot/" },
-         handler:        :get_api_boot },
-       { match_criteria: { method: :get, uri: "/dragon/trace/" },
-         handler:        :get_api_trace },
-       { match_criteria: { method: :get, uri: "/dragon/puts/" },
-         handler:        :get_api_puts },
-       { match_criteria: { method: :get, uri: "/dragon/log/" },
-         handler:        :get_api_log },
        { match_criteria: { method: :post, uri: "/dragon/log/" },
          handler:        :post_api_log },
-       { match_criteria: { method: :get, uri: "/dragon/changes/" },
-         handler:        :get_api_changes },
        { match_criteria: { method: :get, uri: "/dragon/eval/" },
          handler:        :get_api_eval },
        { match_criteria: { method: :post, uri: "/dragon/eval/" },
@@ -626,6 +616,26 @@ S
     end
 
     STATIC_FILES = {
+      '/dragon/boot/' => {
+        source: 'tmp/src_backup/boot.txt',
+        content_type: 'text/plain'
+      },
+      '/dragon/trace/' => {
+        source: 'logs/trace.txt',
+        content_type: 'text/plain'
+      },
+      '/dragon/puts/' => {
+        source: 'logs/puts.txt',
+        content_type: 'text/plain'
+      },
+      '/dragon/log/' => {
+        source: 'logs/log.txt',
+        content_type: 'text/plain'
+      },
+      '/dragon/changes/' => {
+        source: '/tmp/src_backup/src_backup_changes.txt',
+        content_type: 'text/plain'
+      },
       '/docs.html' => {
         source: 'docs/docs.html',
         content_type: 'text/html'

--- a/dragon/api.rb
+++ b/dragon/api.rb
@@ -275,13 +275,6 @@ S
       $eval_results = nil
     end
 
-    def get_api_console args, req
-      html = console_view "# write your code here and set $result.\n$result = $gtk.args.state"
-      req.respond 200,
-                  html,
-                  { 'Content-Type' => 'text/html' }
-    end
-
     def control_panel_view
       <<-S
 <html lang="en">
@@ -441,10 +434,6 @@ S
          handler:        :get_api_eval },
        { match_criteria: { method: :post, uri: "/dragon/eval/" },
          handler:        :post_api_eval },
-       { match_criteria: { method: :get, uri: "/dragon/console/" },
-         handler:        :get_api_console },
-       { match_criteria: { method: :post, uri: "/dragon/console/" },
-         handler:        :post_api_console },
        { match_criteria: { method: :get, uri: "/dragon/control_panel/" },
          handler:        :get_api_control_panel },
        { match_criteria: { method: :post, uri: "/dragon/reset/" },

--- a/dragon/api.rb
+++ b/dragon/api.rb
@@ -187,12 +187,6 @@ S
                   { 'Content-Type' => 'text/html' }
     end
 
-    def get_api_log args, req
-      req.respond 200,
-                  args.gtk.read_file("logs/log.txt"),
-                  { 'Content-Type' => 'text/plain' }
-    end
-
     def post_api_log args, req
       Log.log req.body
 


### PR DESCRIPTION
Refactored static file routes to be defined in one Hash constant and to be handled by two handler methods (one for cached files and one for uncached ones).

Also removed some old/outdated and duplicated route entries