### PR TITLE
Dev HTTP Server: Fix URL and query string parsing

### DIFF
--- a/dragon/api.rb
+++ b/dragon/api.rb
@@ -165,7 +165,8 @@ S
     end
 
     def get_api_code_edit args, req
-      file = req.uri.split('?').last.gsub("file=", "")
+      _, query_string = get_uri_and_query_string req
+      file = query_string.gsub("file=", "")
       view = code_edit_view args, file
       req.respond 200,
                   view,
@@ -173,7 +174,8 @@ S
     end
 
     def post_api_code_update args, req
-      file = req.uri.split('?').last.gsub("file=", "")
+      _, query_string = get_uri_and_query_string req
+      file = query_string.gsub("file=", "")
       code = ($gtk.parse_json req.body)["code"]
       args.gtk.write_file file, code
       view = code_edit_view args, file

--- a/dragon/api.rb
+++ b/dragon/api.rb
@@ -165,8 +165,8 @@ S
     end
 
     def get_api_code_edit args, req
-      _, query_string = get_uri_and_query_string req
-      file = query_string.gsub("file=", "")
+      query_params = get_query_params req
+      file = query_params['file']
       view = code_edit_view args, file
       req.respond 200,
                   view,
@@ -174,8 +174,8 @@ S
     end
 
     def post_api_code_update args, req
-      _, query_string = get_uri_and_query_string req
-      file = query_string.gsub("file=", "")
+      query_params = get_query_params req
+      file = query_params['file']
       code = ($gtk.parse_json req.body)["code"]
       args.gtk.write_file file, code
       view = code_edit_view args, file
@@ -625,6 +625,13 @@ S
                     { 'Content-Type' => 'text/plain' }
       end
       return true
+    end
+
+    def get_query_params req
+      _, query_string = get_uri_and_query_string req
+      query_string.split('&').map { |pair|
+        pair.split('=')
+      }.to_h
     end
 
     def get_uri_and_query_string req

--- a/dragon/api.rb
+++ b/dragon/api.rb
@@ -449,15 +449,18 @@ S
 
     def tick args
       args.inputs.http_requests.each do |req|
+        uri = req.uri
+        has_query_string = uri.include? '?'
+        uri_without_query_string = has_query_string ? uri.split('?').first : uri
         match_candidate = { method:                   req.method.downcase.to_sym,
-                            uri:                      req.uri,
-                            uri_without_query_string: (req.uri.split '?').first,
-                            query_string:             (req.uri.split '?').last,
-                            has_query_string:         !!(req.uri.split '?').last,
-                            has_api_prefix:           (req.uri.start_with? "/dragon"),
-                            end_with_rb:              (req.uri.end_with? ".rb"),
-                            has_file_extension:       file_extensions.find { |f| req.uri.include? f },
-                            has_trailing_slash:       (req.uri.split('?').first.end_with? "/") }
+                            uri:                      uri,
+                            uri_without_query_string: uri_without_query_string,
+                            query_string:             has_query_string ? uri.split('?').last : nil,
+                            has_query_string:         has_query_string,
+                            has_api_prefix:           uri.start_with?('/dragon'),
+                            end_with_rb:              uri.end_with?('.rb'),
+                            has_file_extension:       file_extensions.find { |f| uri.include? f },
+                            has_trailing_slash:       uri_without_query_string.end_with?('/') }
 
         if !match_candidate[:has_file_extension]
           if !match_candidate[:has_trailing_slash]

--- a/dragon/api.rb
+++ b/dragon/api.rb
@@ -451,11 +451,11 @@ S
       args.inputs.http_requests.each do |req|
         uri = req.uri
         has_query_string = uri.include? '?'
-        uri_without_query_string = has_query_string ? uri.split('?').first : uri
+        uri_without_query_string = has_query_string ? uri.split('?', 2).first : uri
         match_candidate = { method:                   req.method.downcase.to_sym,
                             uri:                      uri,
                             uri_without_query_string: uri_without_query_string,
-                            query_string:             has_query_string ? uri.split('?').last : nil,
+                            query_string:             has_query_string ? uri.split('?', 2).last : nil,
                             has_query_string:         has_query_string,
                             end_with_rb:              uri.end_with?('.rb'),
                             has_file_extension:       file_extensions.find { |f| uri.include? f },

--- a/dragon/api.rb
+++ b/dragon/api.rb
@@ -457,7 +457,6 @@ S
                             uri_without_query_string: uri_without_query_string,
                             query_string:             has_query_string ? uri.split('?').last : nil,
                             has_query_string:         has_query_string,
-                            has_api_prefix:           uri.start_with?('/dragon'),
                             end_with_rb:              uri.end_with?('.rb'),
                             has_file_extension:       file_extensions.find { |f| uri.include? f },
                             has_trailing_slash:       uri_without_query_string.end_with?('/') }

--- a/dragon/api.rb
+++ b/dragon/api.rb
@@ -461,13 +461,10 @@ S
                             has_file_extension:       file_extensions.find { |f| uri.include? f },
                             has_trailing_slash:       uri_without_query_string.end_with?('/') }
 
-        if !match_candidate[:has_file_extension]
-          if !match_candidate[:has_trailing_slash]
-            match_candidate[:uri] = match_candidate[:uri_without_query_string] + "/"
-            if match_candidate[:query_string]
-              match_candidate[:uri] += "?#{match_candidate[:query_string]}"
-            end
-          end
+        if !match_candidate[:has_file_extension] && !match_candidate[:has_trailing_slash]
+          match_candidate[:uri_without_query_string] += '/'
+          match_candidate[:uri] = match_candidate[:uri_without_query_string]
+          match_candidate[:uri] += "?#{match_candidate[:query_string]}" if has_query_string
         end
 
         context = { args: args, req: req, match_candidate: match_candidate }


### PR DESCRIPTION
There was a problem with query string parsing in the current implementation - since `uri.split('?').last` would always return something whether there is a query string or not... So I fixed and refactored the query string parsing a bit....

I also got rid of `uri_without_query_string` and instead make sure that `uri` never contains the query string...