### PR TITLE
Dev HTTP Server: Refactor html pages

### DIFF
--- a/dragon/api.rb
+++ b/dragon/api.rb
@@ -91,46 +91,35 @@ module GTK
     end
 
     def code_edit_view args, file
-      view = <<-S
-<html>
-  <head>
-    <meta charset="UTF-8"/>
-    <title>DragonRuby Game Toolkit Documentation</title>
-  </head>
-  <body>
-      <script>
-        async function submitForm() {
-          const result = await fetch("/dragon/code/update/?file=#{file}", {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ code: document.getElementById("code").value }),
-          });
-          document.getElementById("success-notification").innerHTML = "update successful";
-          setTimeout(function() { document.getElementById("success-notification").innerHTML = ""; }, 3000);
-        }
-      </script>
-      <form>
-        <div><code>#{file}:</code></div>
-        <textarea name="code" id="code" rows="30" cols="80">#{args.gtk.read_file file}</textarea>
-        <br/>
-        <input type="button" value="Update" onclick="submitForm();" />
-        <span id="success-notification"></span>
-      </form>
-    #{source_code_links args}
+      <<~HTML
+        <script>
+          async function submitForm() {
+            const result = await fetch("/dragon/code/update/?file=#{file}", {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ code: document.getElementById("code").value }),
+            });
+            document.getElementById("success-notification").innerHTML = "update successful";
+            setTimeout(function() { document.getElementById("success-notification").innerHTML = ""; }, 3000);
+          }
+        </script>
+        <form>
+          <div><code>#{file}:</code></div>
+          <textarea name="code" id="code" rows="30" cols="80">#{args.gtk.read_file file}</textarea>
+          <br/>
+          <input type="button" value="Update" onclick="submitForm();" />
+          <span id="success-notification"></span>
+        </form>
+        #{source_code_links args}
 
-    #{links}
-  </body>
-</html>
-S
+        #{links}
+      HTML
     end
 
     def get_api_code_edit args, req
       query_params = get_query_params req
       file = query_params['file']
-      view = code_edit_view args, file
-      req.respond 200,
-                  view,
-                  { 'Content-Type' => 'text/html' }
+      respond_with_html req, code_edit_view(args, file)
     end
 
     def post_api_code_update args, req
@@ -140,10 +129,7 @@ S
         code = ($gtk.parse_json req.body)["code"]
         args.gtk.write_file file, code
       end
-      view = code_edit_view args, file
-      req.respond 200,
-                  view,
-                  { 'Content-Type' => 'text/html' }
+      respond_with_html req, code_edit_view(args, file)
     end
 
     def post_api_log args, req

--- a/dragon/api.rb
+++ b/dragon/api.rb
@@ -200,48 +200,37 @@ module GTK
       $eval_results = nil
     end
 
-    def control_panel_view
-      <<-S
-<html lang="en">
-  <head><title>console</title></head>
-  <body>
-    <script>
-      async function submitForm(url) {
-        const result = await fetch(url, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({}),
-        });
-        document.getElementById("success-notification").innerHTML = "successful";
-        setTimeout(function() { document.getElementById("success-notification").innerHTML = ""; }, 3000);
-      }
-    </script>
-    <form>
-      <input type="button" value="Show Console" onclick="submitForm('/dragon/show_console/')" />
-    </form>
-    <form>
-      <input type="button" value="Reset Game" onclick="submitForm('/dragon/reset/');" />
-    </form>
-    <form>
-      <input type="button" value="Record Gameplay" onclick="submitForm('/dragon/record/');" />
-    </form>
-    <form>
-      <input type="button" value="Stop Recording" onclick="submitForm('/dragon/record_stop/');" />
-    </form>
-    <form>
-      <input type="button" value="Replay Recording" onclick="submitForm('/dragon/replay/');" />
-    </form>
-    <div id="success-notification"></div>
-    #{links}
-  </body>
-</html>
-S
-    end
-
     def get_api_control_panel args, req
-      req.respond 200,
-                  control_panel_view,
-                  { 'Content-Type' => 'text/html' }
+      respond_with_html req, <<~HTML
+        <script>
+          async function submitForm(url) {
+            const result = await fetch(url, {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({}),
+            });
+            document.getElementById("success-notification").innerHTML = "successful";
+            setTimeout(function() { document.getElementById("success-notification").innerHTML = ""; }, 3000);
+          }
+        </script>
+        <form>
+          <input type="button" value="Show Console" onclick="submitForm('/dragon/show_console/')" />
+        </form>
+        <form>
+          <input type="button" value="Reset Game" onclick="submitForm('/dragon/reset/');" />
+        </form>
+        <form>
+          <input type="button" value="Record Gameplay" onclick="submitForm('/dragon/record/');" />
+        </form>
+        <form>
+          <input type="button" value="Stop Recording" onclick="submitForm('/dragon/record_stop/');" />
+        </form>
+        <form>
+          <input type="button" value="Replay Recording" onclick="submitForm('/dragon/replay/');" />
+        </form>
+        <div id="success-notification"></div>
+        #{links}
+      HTML
     end
 
     def json? req
@@ -250,37 +239,27 @@ S
 
     def post_api_reset args, req
       $gtk.reset if json? req
-      req.respond 200,
-                  control_panel_view,
-                  { 'Content-Type' => 'text/html' }
+      get_api_control_panel args, req
     end
 
     def post_api_record args, req
       $recording.start 100 if json? req
-      req.respond 200,
-                  control_panel_view,
-                  { 'Content-Type' => 'text/html' }
+      get_api_control_panel args, req
     end
 
     def post_api_record_stop args, req
       $recording.stop 'replay.txt' if json? req
-      req.respond 200,
-                  control_panel_view,
-                  { 'Content-Type' => 'text/html' }
+      get_api_control_panel args, req
     end
 
     def post_api_replay args, req
       $replay.start 'replay.txt' if json? req
-      req.respond 200,
-                  control_panel_view,
-                  { 'Content-Type' => 'text/html' }
+      get_api_control_panel args, req
     end
 
     def post_api_show_console args, req
       $gtk.console.show if json? req
-      req.respond 200,
-                  control_panel_view,
-                  { 'Content-Type' => 'text/html' }
+      get_api_control_panel args, req
     end
 
     def tick args

--- a/dragon/api.rb
+++ b/dragon/api.rb
@@ -52,17 +52,17 @@ module GTK
     end
 
     def links
-      <<-S
-    <ul>
-      <li><a href="/">Home</a></li>
-      <li><a href="/docs.html">Docs</a></li>
-      <li><a href="/dragon/control_panel/">Control Panel</a></li>
-      <li><a href="/dragon/eval/">Console</a></li>
-      <li><a href="/dragon/log/">Logs</a></li>
-      <li><a href="/dragon/puts/">Puts</a></li>
-      <li><a href="/dragon/code/">Code</a></li>
-    </ul>
-S
+      <<~HTML
+        <ul>
+          <li><a href="/">Home</a></li>
+          <li><a href="/docs.html">Docs</a></li>
+          <li><a href="/dragon/control_panel/">Control Panel</a></li>
+          <li><a href="/dragon/eval/">Console</a></li>
+          <li><a href="/dragon/log/">Logs</a></li>
+          <li><a href="/dragon/puts/">Puts</a></li>
+          <li><a href="/dragon/code/">Code</a></li>
+        </ul>
+      HTML
     end
 
     def get_index args, req

--- a/dragon/api.rb
+++ b/dragon/api.rb
@@ -75,30 +75,19 @@ module GTK
       links = args.gtk.reload_list_history.keys.map do |f|
         "<li><a href=\"/dragon/code/edit/?file=#{f}\">#{f}</a></li>"
       end
-      <<-S
-<ul>
-  #{links.join("\n")}
-</ul>
-S
+      <<~HTML
+        <ul>
+          #{links.join("\n")}
+        </ul>
+      HTML
     end
 
     def get_api_code args, req
-      view = <<-S
-<html>
-  <head>
-    <meta charset="UTF-8"/>
-    <title>DragonRuby Game Toolkit Documentation</title>
-  </head>
-  <body>
-    #{source_code_links args}
+      respond_with_html req, <<~HTML
+        #{source_code_links args}
 
-    #{links}
-  </body>
-</html>
-S
-      req.respond 200,
-                  view,
-                  { 'Content-Type' => 'text/html' }
+        #{links}
+      HTML
     end
 
     def code_edit_view args, file

--- a/dragon/api.rb
+++ b/dragon/api.rb
@@ -75,7 +75,7 @@ S
       req.respond 200, list_as_string, { 'Content-Type' => 'text/plain' }
     end
 
-    define_method :links do
+    def links
       <<-S
     <ul>
       <li><a href="/">Home</a></li>

--- a/dragon/api.rb
+++ b/dragon/api.rb
@@ -156,47 +156,27 @@ module GTK
     end
 
     def get_api_eval args, req
-      eval_view = <<-S
-<html lang="en">
-  <head><title>Eval</title></head>
-  <style>
-  pre {
-    border: solid 1px silver;
-    padding: 10px;
-    font-size: 14px;
-    white-space: pre-wrap;
-    white-space: -moz-pre-wrap;
-    white-space: -pre-wrap;
-    white-space: -o-pre-wrap;
-    word-wrap: break-word;
-  }
-  </style>
-  <body>
-    <script>
-      async function submitForm() {
-          const result = await fetch("/dragon/eval/", {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ code: document.getElementById("code").value }),
-          });
-          document.getElementById("eval-result").innerHTML = await result.text();
-      }
-    </script>
-    <form>
-      <textarea name="code" id="code" rows="10" cols="80"># write your code here and set $result.\n$result = $gtk.args.state</textarea>
-      <br/>
-      <input type="button" onclick="submitForm();" value="submit" />
-    </form>
-    <pre>curl -H "Content-Type: application/json" --data '{ "code": "$result = $args.state" }' -X POST http://localhost:9001/dragon/eval/</pre>
-    <div>Eval Result:</div>
-    <pre id="eval-result"></pre>
-    #{links}
-  </body>
-</html>
-S
-      req.respond 200,
-                  eval_view,
-                  { 'Content-Type' => 'text/html' }
+      respond_with_html req, <<~HTML, title: 'Eval'
+        <script>
+          async function submitForm() {
+              const result = await fetch("/dragon/eval/", {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ code: document.getElementById("code").value }),
+              });
+              document.getElementById("eval-result").innerHTML = await result.text();
+          }
+        </script>
+        <form>
+          <textarea name="code" id="code" rows="10" cols="80"># write your code here and set $result.\n$result = $gtk.args.state</textarea>
+          <br/>
+          <input type="button" onclick="submitForm();" value="submit" />
+        </form>
+        <pre>curl -H "Content-Type: application/json" --data '{ "code": "$result = $args.state" }' -X POST http://localhost:9001/dragon/eval/</pre>
+        <div>Eval Result:</div>
+        <pre id="eval-result"></pre>
+        #{links}
+      HTML
     end
 
     def post_api_eval args, req

--- a/dragon/api.rb
+++ b/dragon/api.rb
@@ -12,58 +12,34 @@ module GTK
     end
 
     def get_api_autocomplete args, req
-      html = <<-S
-<html>
-  <head>
-    <meta charset="UTF-8"/>
-    <title>DragonRuby Game Toolkit Documentation</title>
-    <style>
-    pre {
-      border: solid 1px silver;
-      padding: 10px;
-      font-size: 14px;
-      white-space: pre-wrap;
-      white-space: -moz-pre-wrap;
-      white-space: -pre-wrap;
-      white-space: -o-pre-wrap;
-      word-wrap: break-word;
-    }
-    </style>
-  </head>
-  <body>
-      <script>
-        async function submitForm() {
-          const result = await fetch("/dragon/autocomplete/", {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ index: document.getElementById("index").value,
-                                   text: document.getElementById("text").value }),
-          });
-          document.getElementById("autocomplete-results").innerHTML = await result.text();
-        }
-      </script>
-      <form>
-        <div>index</div>
-        <input name="index" id="index" type="text" value="27" />
-        <div>code</div>
-        <textarea name="text" id="text" rows="30" cols="80">def tick args
-  args.state.
-end</textarea>
-        <br/>
-        <input type="button" value="Get Suggestions" onclick="submitForm();" />
-        <span id="success-notification"></span>
-      </form>
-      <pre id="autocomplete-results">
-      </pre>
+      respond_with_html req, <<~HTML
+        <script>
+          async function submitForm() {
+            const result = await fetch("/dragon/autocomplete/", {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ index: document.getElementById("index").value,
+                                    text: document.getElementById("text").value }),
+            });
+            document.getElementById("autocomplete-results").innerHTML = await result.text();
+          }
+        </script>
+        <form>
+          <div>index</div>
+          <input name="index" id="index" type="text" value="27" />
+          <div>code</div>
+          <textarea name="text" id="text" rows="30" cols="80">def tick args
+          args.state.
+        end</textarea>
+          <br/>
+          <input type="button" value="Get Suggestions" onclick="submitForm();" />
+          <span id="success-notification"></span>
+        </form>
+        <pre id="autocomplete-results">
+        </pre>
 
-    #{links}
-  </body>
-</html>
-S
-
-      req.respond 200,
-                  html,
-                  { 'Content-Type' => 'text/html' }
+        #{links}
+      HTML
     end
 
     def post_api_autocomplete args, req

--- a/dragon/api.rb
+++ b/dragon/api.rb
@@ -72,12 +72,15 @@ module GTK
     end
 
     def source_code_links args
-      links = args.gtk.reload_list_history.keys.map do |f|
-        "<li><a href=\"/dragon/code/edit/?file=#{f}\">#{f}</a></li>"
+      links = ''
+      args.gtk.reload_list_history.each_key do |f|
+        links << <<~HTML
+          <li><a href="/dragon/code/edit/?file=#{f}">#{f}</a></li>
+        HTML
       end
       <<~HTML
         <ul>
-          #{links.join("\n")}
+          #{links}
         </ul>
       HTML
     end

--- a/dragon/api.rb
+++ b/dragon/api.rb
@@ -594,5 +594,39 @@ S
     def get_uri_and_query_string req
       req.uri.split('?', 2)
     end
+
+    def respond_with_html req, body, title: nil, head_content: nil
+      html = <<~HTML
+        <html lang="en">
+          <head>
+            <meta charset="UTF-8"/>
+            <title>#{title || 'DragonRuby Game Toolkit Dev Server'}</title>
+            <style>
+              #{dev_server_css}
+            </style>
+            #{head_content || ''}
+          </head>
+          <body>
+            #{body}
+          </body>
+        </html>
+      HTML
+      req.respond 200, html, { 'Content-Type' => 'text/html' }
+    end
+
+    def dev_server_css
+      <<~CSS
+        pre {
+          border: solid 1px silver;
+          padding: 10px;
+          font-size: 14px;
+          white-space: pre-wrap;
+          white-space: -moz-pre-wrap;
+          white-space: -pre-wrap;
+          white-space: -o-pre-wrap;
+          word-wrap: break-word;
+        }
+      CSS
+    end
   end
 end

--- a/dragon/api.rb
+++ b/dragon/api.rb
@@ -66,17 +66,9 @@ module GTK
     end
 
     def get_index args, req
-      req.respond 200, <<-S, { 'Content-Type' => 'text/html' }
-<html>
-  <head>
-    <meta charset="UTF-8"/>
-    <title>DragonRuby Game Toolkit Documentation</title>
-  </head>
-  <body>
-    #{links}
-  </body>
-</html>
-S
+      respond_with_html req, <<~HTML
+        #{links}
+      HTML
     end
 
     def source_code_links args


### PR DESCRIPTION
There was a lot of duplication in the common HTML of the internal web server so I refactored some stuff
- Extracted a common `respond_with_html` method which generates the common HTML boilerplate, includes the styles etc
- Refactored all pages using the new helper above
- Used squiggly heredocs instead of the normal ones since I think with the indentation it just looks nicer ;)