### PR TITLE
Fix the match criteria of the static file routes

### DIFF
--- a/dragon/api.rb
+++ b/dragon/api.rb
@@ -495,7 +495,7 @@ S
     def static_file_routes
       STATIC_FILES.map { |uri, file_info|
         {
-          match_criteria: { method: :get, uri_without_query_string: uri },
+          match_criteria: { method: :get, uri: uri },
           handler: file_info[:cached] ? :get_cached_static_file : :get_static_file
         }
       }


### PR DESCRIPTION
In #112 simplified the URL matching to always have the URI **without** query string in the `uri` key of the match criteria...

But in #110 I had still used the old key `uri_without_query_string` which is why the routes didn't work (I am actually surprised that any of the static files worked - if they did 🙈 )

This should work now ;)