### PR TITLE
Use begin blocks to improve console eval

### DIFF
--- a/dragon/console_evaluator.rb
+++ b/dragon/console_evaluator.rb
@@ -52,12 +52,16 @@ module GTK
 
 locals[:args] ||= $args
 locals[:gtk]  ||= $gtk
-_ = (#{cmd})
 
-local_variables.each do |name|
-  locals[name] = eval(name.to_s)
+begin
+  _ = begin
+    #{cmd}
+  end
+ensure
+  local_variables.each do |name|
+    locals[name] = eval(name.to_s)
+  end
 end
-_
 S
 
         GTK::ConsoleEvaluator.instance_eval code


### PR DESCRIPTION
- Local vars will be stored even if an exception is thrown.
- Commenting out some or all of the line won't make a syntax error.