### PR TITLE
Add documentation section about accessing files

### DIFF
--- a/dragon/readme_docs.rb
+++ b/dragon/readme_docs.rb
@@ -19,6 +19,7 @@ module GTK
         docs_labels
         docs_sounds
         docs_game_state
+        docs_accessing_files
         docs_troubleshooting_performance
       ]
     end
@@ -930,6 +931,39 @@ sure_ you've initialized a default value.
     ]
   end
 #+end_src
+S
+    end
+
+    def docs_accessing_files
+      <<-S
+** Accessing files
+
+DragonRuby uses a sandboxed filesystem which will automatically read from and
+write to a location appropriate for your platform so you don't have to worry
+about theses details in your code. You can just use ~gtk.read_file~,
+~gtk.write_file~, and ~gtk.append_file~ with a relative path and the engine
+will take care of the rest.
+
+The data directories that will be written to in a production build are:
+
+- Windows: ~C:\\Users\\[username]\\AppData\\Roaming\\[devtitle]\\[gametitle]~
+- MacOS: ~$HOME/Library/Application Support/[gametitle]~
+- Linux: ~$HOME/.local/share/[gametitle]~
+
+The values in square brackets are the values you set in your
+~app/metadata/game_metadata.txt~ file.
+
+When reading files, the engine will first look in the game's data directory
+and then in the game directory itself. This means that if you write a file
+to the data directory that already exists in your game directory, the file
+in the data directory will be used instead of the one that is in your game.
+
+When running a development build you will directly write to your game
+directory (and thus overwrite existing files). This can be useful for built-in
+development tools like level editors.
+
+For more details on the implementation of the sandboxed filesystem, see Ryan
+C. Gordon's PhysicsFS documentation: [[https://icculus.org/physfs/]]
 S
     end
 

--- a/dragon/readme_docs.rb
+++ b/dragon/readme_docs.rb
@@ -6,20 +6,20 @@
 module GTK
   module ReadMeDocs
     def docs_method_sort_order
-      [
-        :docs_usage,
-        :docs_hello_world,
-        :docs_new_project,
-        :docs_deployment,
-        :docs_deployment_mobile,
-        :docs_dragonruby_philosophy,
-        :docs_faq,
-        :docs_ticks_and_frames,
-        :docs_sprites,
-        :docs_labels,
-        :docs_sounds,
-        :docs_game_state,
-        :docs_troubleshooting_performance
+      %i[
+        docs_usage
+        docs_hello_world
+        docs_new_project
+        docs_deployment
+        docs_deployment_mobile
+        docs_dragonruby_philosophy
+        docs_faq
+        docs_ticks_and_frames
+        docs_sprites
+        docs_labels
+        docs_sounds
+        docs_game_state
+        docs_troubleshooting_performance
       ]
     end
 

--- a/dragon/readme_docs.rb
+++ b/dragon/readme_docs.rb
@@ -949,6 +949,7 @@ The data directories that will be written to in a production build are:
 - Windows: ~C:\\Users\\[username]\\AppData\\Roaming\\[devtitle]\\[gametitle]~
 - MacOS: ~$HOME/Library/Application Support/[gametitle]~
 - Linux: ~$HOME/.local/share/[gametitle]~
+- HTML5: The data will be written to the browser's IndexedDB.
 
 The values in square brackets are the values you set in your
 ~app/metadata/game_metadata.txt~ file.


### PR DESCRIPTION
It always bothered me that this was not properly documented anywhere... so I tried and wrote a documentation section about it...

I didn't include the locations for Android/iPhone since I'm not familiar enough with the conventions there - and I didn't have a game on hand to try it out...