### PR TITLE
Docs : Add small entries for find_intersect_rect and find_collisions

### DIFF
--- a/dragon/outputs_docs.rb
+++ b/dragon/outputs_docs.rb
@@ -219,9 +219,9 @@ be provided in any order.
   end
 #+end_src
 
-** Rendering a solid using a Class
+** Rendering a sprite using a Class
 
-You can also create a class with solid/border properties and render it as a primitive.
+You can also create a class with sprite properties and render it as a primitive.
 ALL properties must be on the class. *Additionally*, a method called ~primitive_marker~
 must be defined on the class.
 

--- a/dragon/outputs_docs.rb
+++ b/dragon/outputs_docs.rb
@@ -222,24 +222,17 @@ be provided in any order.
 ** Rendering a sprite using a Class
 
 You can also create a class with sprite properties and render it as a primitive.
-ALL properties must be on the class. *Additionally*, a method called ~primitive_marker~
-must be defined on the class.
 
-Here is an example:
+A sprite class needs to have all of the properties of a sprite, plus a special ~primitive_marker~.
+
+To make this easy, use the ~attr_sprite~ module.
 
 #+begin_src
-  # Create type with ALL sprite properties AND primitive_marker
-  class Sprite
-    attr_accessor :x, :y, :w, :h, :path, :angle, :angle_anchor_x, :angle_anchor_y,  :tile_x, :tile_y, :tile_w, :tile_h, :source_x, :source_y, :source_w, :source_h, :flip_horizontally, :flip_vertically, :a, :r, :g, :b
+  # Create sprite type using the attr_sprite Module
+  class Circle
+    attr_sprite
 
-    def primitive_marker
-      :sprite
-    end
-  end
-
-  # Inherit from type
-  class Circle < Sprite
-  # constructor
+    # constructor
     def initialize x, y, size, path
       self.x = x
       self.y = y
@@ -247,6 +240,7 @@ Here is an example:
       self.h = size
       self.path = path
     end
+
     def serlialize
       {x:self.x, y:self.y, w:self.w, h:self.h, path:self.path}
     end
@@ -259,11 +253,14 @@ Here is an example:
       serlialize.to_s
     end
   end
+
   def tick args
     # render circle sprite
     args.outputs.sprites  << Circle.new(10, 10, 32,"sprites/circle/white.png")
   end
 #+end_src
+
+You can see the full list of sprite properties in the ruby module : [[https://github.com/DragonRuby/dragonruby-game-toolkit-contrib/blob/master/dragon/attr_sprite.rb]].
 
 S
   end

--- a/dragon/runtime_docs.rb
+++ b/dragon/runtime_docs.rb
@@ -334,6 +334,12 @@ Here are some general notes with regards to the arguments these geometric functi
 Returns ~true~ if ~rect_1~ is inside ~rect_2~.
 ** ~args.geometry.intersect_rect? rect_1, rect_2~
 Returns ~true~ if ~rect_1~ intersects ~rect_2~.
+** ~args.geometry.find_intersect_rect rect_1, other_rects~
+Returns the first rect from the ~other_rects~ ~Array~ that intersects with ~rect_1~, or ~nil~ if there are no intersections.
+** ~args.geometry.find_collisions rects~
+Given an ~Array~ of rects, returns a ~Hash~ of collisions. Each entry maps two rects from the input ~Array~ that intersect.
+
+Note that in the event of an intersection of rects ~A~ and ~B~, the returned ~Hash~ will contain two entries: ~{A=>B,B=>A}~
 ** ~args.geometry.scale_rect rect, x_percentage, y_percentage~
 Returns a new rectangle that is scaled by the percentages provided.
 ** ~args.geometry.angle_to start_point, end_point~


### PR DESCRIPTION
### Context

Small PR to add doco on inputs/outputs for the following methods:

- find_intersect_rect
- find_collisions

Also includes some changes to the Outputs/Sprites section:

- A copy paste error which looked like a mistake mixing up solid/sprite.
- Updating the sprite example to use `attr_sprite` and linking to the module for more detail on all available properties.

I've successfully generated the docs locally, to test that formatting is correct.

![image](https://user-images.githubusercontent.com/179979/203545367-53264b0a-d127-4642-8bd2-57ca9f29c44b.png)
