### PR TITLE
Documentation: fix typo: change `map` to `each`

### DIFF
--- a/dragon/array_docs.rb
+++ b/dragon/array_docs.rb
@@ -288,7 +288,7 @@ Example of using ~Array#each~ in conjunction with ~args.state~ and
     # with a width and height of 50.
     args.state
         .rainbow_colors
-        .map do |color| # <-- ~Array#each~ usage
+        .each do |color| # <-- ~Array#each~ usage
           args.outputs.sprites << [
             color[:order] * 50,
             color[:order] * 50,


### PR DESCRIPTION
The example is for `#each`, but erroneously uses `#map`