### PR TITLE
Don't constrain easing function to [0,1] output.

### DIFF
--- a/dragon/easing.rb
+++ b/dragon/easing.rb
@@ -55,9 +55,9 @@ module GTK
 
     def self.exec_definition definition, start_tick, duration, x
       if definition.is_a? Symbol
-        return Easing.send(definition, x).cap_min_max(0, 1)
+        return Easing.send(definition, x)
       elsif definition.is_a? Proc
-        return definition.call(x, start_tick, duration).cap_min_max(0, 1)
+        return definition.call(x, start_tick, duration)
       end
 
       raise <<-S


### PR DESCRIPTION
There are legitimate uses of easing functions that output an animation progress < 0 or > 1. This allows the animation to overshoot its target or start with a wind-up that moves away from its target for a brief period. For example, the following easing function does not display correctly without this change:

```ruby
proc { |t| GTK::Geometry.cubic_bezier(t, 0, -1, 2, 1) }
```