### PR TITLE
Proof of Concept - API Doc Generation

### DIFF
--- a/deploy_template/.dragonruby/stubs/docs/api_docs.html
+++ b/deploy_template/.dragonruby/stubs/docs/api_docs.html
@@ -9,14 +9,58 @@
         width: 50%;
         font-size: 1.5em;
       }
+
+      .api-entry {
+        /* TODO */
+      }
     </style>
   </head>
   <body>
     <h1>DragonRuby API Docs</h1>
     <input type="text" id="search" placeholder="Search..." />
+    <div id="results">
+
+    </div>
 
     <script>
       // ----- EXPORT PLACEHOLDER: API ENTRIES -----
+
+      const resultsElement = document.getElementById('results');
+      const searchElement = document.getElementById('search');
+
+      function apiEntriesMatching(searchValue) {
+        const results = [];
+        for (const entry of API_ENTRIES) {
+          if (entry.entry_name.toLowerCase().includes(searchValue.toLowerCase())) {
+            results.push(entry);
+          }
+        }
+        return results;
+      }
+
+      function renderEntry(entry) {
+        const text = entry.raw_text.replaceAll("\n", '<br />')
+        return `
+          <h2>${entry.entry_name}</h2>
+          <p>${text}</p>
+        `;
+      }
+
+      function updateSearchResults() {
+        const results = apiEntriesMatching(searchElement.value);
+
+        resultsElement.innerHTML = '';
+        for (const entry of results) {
+          const element = document.createElement('div');
+          element.className = 'api-entry';
+          element.innerHTML = renderEntry(entry)
+          resultsElement.appendChild(element);
+        }
+      }
+
+      searchElement.addEventListener('input', updateSearchResults);
+
+      updateSearchResults();
     </script>
   </body>
 </html>

--- a/deploy_template/.dragonruby/stubs/docs/api_docs.html
+++ b/deploy_template/.dragonruby/stubs/docs/api_docs.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en-us">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <title>DragonRuby API Docs</title>
+    <style>
+      #search {
+        width: 50%;
+        font-size: 1.5em;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>DragonRuby API Docs</h1>
+    <input type="text" id="search" placeholder="Search..." />
+
+    <script>
+      // ----- EXPORT PLACEHOLDER: API ENTRIES -----
+    </script>
+  </body>
+</html>

--- a/dragon/api_doc_export.rb
+++ b/dragon/api_doc_export.rb
@@ -1,0 +1,40 @@
+module GTK
+  module ApiDocExport
+    class << self
+      def export
+        entries = []
+        $docs_classes.each do |klass|
+          next if klass == GTK::ReadMe # Ignore text content of docs
+
+          DocsOrganizer.find_methods_with_docs(klass).each do |doc_method|
+            next if doc_method == :docs_class # Ignore class description
+            next if doc_method.to_s.start_with?('docs_api_summary') # Ignore API summary texts
+
+            entry = {
+              class: klass.name,
+              method: doc_method.to_s[5..],
+              raw_text: klass.send(doc_method)
+            }
+            puts "Exporting docs for #{entry[:class]}##{entry[:method]}"
+            entries << entry
+          end
+        end
+
+        $gtk.write_file_root 'docs/api_docs.json', build_json(entries)
+      end
+
+      private
+
+      def build_json(object)
+        case object
+        when String
+          object.gsub('"', '\"').inspect
+        when Hash
+          "{#{object.map { |k, v| "#{k.to_s.inspect}: #{build_json(v)}" }.join(',')}}"
+        when Array
+          "[#{object.map { |v| build_json(v) }.join(',')}]"
+        end
+      end
+    end
+  end
+end

--- a/dragon/api_doc_export.rb
+++ b/dragon/api_doc_export.rb
@@ -5,12 +5,14 @@ module GTK
         entries = []
 
         api_doc_methods.each do |klass, doc_method|
+          method_name = doc_method.to_s[5..]
           entry = {
-            class: klass.name,
-            method: doc_method.to_s[5..],
+            class_name: klass.name,
+            method_name: method_name,
+            entry_name: entry_name(klass, method_name),
             raw_text: klass.send(doc_method)
           }
-          puts "Exporting docs for #{entry[:class]}##{entry[:method]}"
+          puts "Exporting docs for #{entry[:entry_name]}"
           entries << entry
         end
 
@@ -34,6 +36,18 @@ module GTK
           end
         end
         result
+      end
+
+      def entry_name(klass, method_name)
+        if klass == GTK::Runtime
+          "args.gtk.#{method_name}"
+        elsif klass == GTK::Outputs
+          "args.outputs.#{method_name}"
+        elsif klass == GTK::Args
+          "args.#{method_name}"
+        else
+          "#{klass.name}##{method_name}"
+        end
       end
 
       def build_json(object)

--- a/dragon/api_doc_export.rb
+++ b/dragon/api_doc_export.rb
@@ -74,9 +74,9 @@ module GTK
       def escape_json_for_javascript_string_literal(string)
         # Welcome to backslash escape hell, lol
         # Javascript string literals cannot contain real newlines, so we need to escape them
-        result = string.gsub('\\n') { '\\\\\\\\n' }
+        result = string.gsub('\\n') { '\\\\\\\\n' } # \n -> \\n
         # Need to escape single quotes since we're using single quotes for the string literal
-        result.gsub!("'") { "\\\\'" }
+        result.gsub!("'") { "\\\\'" } # ' -> \'
       end
     end
   end

--- a/dragon/api_doc_export.rb
+++ b/dragon/api_doc_export.rb
@@ -3,6 +3,24 @@ module GTK
     class << self
       def export
         entries = []
+
+        api_doc_methods.each do |klass, doc_method|
+          entry = {
+            class: klass.name,
+            method: doc_method.to_s[5..],
+            raw_text: klass.send(doc_method)
+          }
+          puts "Exporting docs for #{entry[:class]}##{entry[:method]}"
+          entries << entry
+        end
+
+        $gtk.write_file_root 'docs/api_docs.json', build_json(entries)
+      end
+
+      private
+
+      def api_doc_methods
+        result = []
         $docs_classes.each do |klass|
           next if klass == GTK::ReadMe # Ignore text content of docs
 
@@ -10,20 +28,11 @@ module GTK
             next if doc_method == :docs_class # Ignore class description
             next if doc_method.to_s.start_with?('docs_api_summary') # Ignore API summary texts
 
-            entry = {
-              class: klass.name,
-              method: doc_method.to_s[5..],
-              raw_text: klass.send(doc_method)
-            }
-            puts "Exporting docs for #{entry[:class]}##{entry[:method]}"
-            entries << entry
+            result << [klass, doc_method]
           end
         end
-
-        $gtk.write_file_root 'docs/api_docs.json', build_json(entries)
+        result
       end
-
-      private
 
       def build_json(object)
         case object

--- a/dragon/kernel_docs.rb
+++ b/dragon/kernel_docs.rb
@@ -68,36 +68,7 @@ S
   end
 
   def export_api_docs!
-    entries = []
-    $docs_classes.each do |klass|
-      next if klass == GTK::ReadMe # Ignore text content of docs
-
-      DocsOrganizer.find_methods_with_docs(klass).each do |doc_method|
-        next if doc_method == :docs_class # Ignore class description
-        next if doc_method.to_s.start_with?('docs_api_summary') # Ignore API summary texts
-
-        entry = {
-          class: klass.name,
-          method: doc_method.to_s[5..],
-          raw_text: klass.send(doc_method)
-        }
-        puts "Exporting docs for #{entry[:class]}##{entry[:method]}"
-        entries << entry
-      end
-    end
-
-    $gtk.write_file_root 'docs/api_docs.json', build_json(entries)
-  end
-
-  def build_json(object)
-    case object
-    when String
-      object.gsub('"', '\"').inspect
-    when Hash
-      "{#{object.map { |k, v| "#{k.to_s.inspect}: #{build_json(v)}" }.join(',')}}"
-    when Array
-      "[#{object.map { |v| build_json(v) }.join(',')}]"
-    end
+    GTK::ApiDocExport.export
   end
 end
 

--- a/dragon/kernel_docs.rb
+++ b/dragon/kernel_docs.rb
@@ -66,6 +66,26 @@ S
 
     nil
   end
+
+  def export_api_docs!
+    entries = []
+    $docs_classes.each do |klass|
+      next if klass == GTK::ReadMe # Ignore text content of docs
+
+      DocsOrganizer.find_methods_with_docs(klass).each do |doc_method|
+        next if doc_method == :docs_class # Ignore class description
+        next if doc_method.to_s.start_with?('docs_api_summary') # Ignore API summary texts
+
+        entry = {
+          class: klass.name,
+          method: doc_method.to_s[5..],
+          raw_text: klass.send(doc_method)
+        }
+        puts "Exporting docs for #{entry[:class]}##{entry[:method]}"
+        entries << entry
+      end
+    end
+  end
 end
 
 module Kernel

--- a/dragon/kernel_docs.rb
+++ b/dragon/kernel_docs.rb
@@ -85,6 +85,19 @@ S
         entries << entry
       end
     end
+
+    $gtk.write_file_root 'docs/api_docs.json', build_json(entries)
+  end
+
+  def build_json(object)
+    case object
+    when String
+      object.gsub('"', '\"').inspect
+    when Hash
+      "{#{object.map { |k, v| "#{k.to_s.inspect}: #{build_json(v)}" }.join(',')}}"
+    when Array
+      "[#{object.map { |v| build_json(v) }.join(',')}]"
+    end
   end
 end
 


### PR DESCRIPTION
Tried to implement a possible API Doc page export function.

It collects all doc methods which are API docs of real methods - converts them into a JSON representation and uses that on a simple generated HTML website with a search bar.

Everything veeeeeeery barebones and ugly so far

A little video of what it currently looks like:

https://user-images.githubusercontent.com/6623784/217549084-eab4ea2b-cb52-430c-a4c1-5f505af92adf.mp4

Yes... parsing the markup is not yet done :D