### PR TITLE
Document *attributes* field in parsed XML

### DIFF
--- a/dragon/runtime_docs.rb
+++ b/dragon/runtime_docs.rb
@@ -447,7 +447,8 @@ represents the xml data in the following recursive structure:
 {
   type: :element,
   name: "Person",
-  children: [...]
+  children: [...],
+  attributes: {...}
 }
 #+end_src
 S


### PR DESCRIPTION
Each XML element in the `parse_xml` results contains an `attributes` Hash that encapsulates the parsed XML element's attributes. This PR documents the `attributes` field and its Hash structure.