### PR TITLE
Colorize tests

### DIFF
--- a/dragon/log.rb
+++ b/dragon/log.rb
@@ -215,10 +215,9 @@ class Object
   end
 
   def log_with_color xterm_escape_code, *args
-    log_print xterm_escape_code
-    log(*args)
-  ensure
-    log_reset_color
+    message_id, message = args
+    message ||= message_id
+    log("#{xterm_escape_code}#{message}#{XTERM_COLOR[:reset]}")
   end
 
   def log_reset_color

--- a/dragon/tests.rb
+++ b/dragon/tests.rb
@@ -48,7 +48,7 @@ module GTK
 
     # @gtk
     def start
-      log "* TEST: gtk.test.start has been invoked."
+      log_cyan "* TEST: gtk.test.start has been invoked."
       if test_methods_focused.length != 0
         @is_running = true
         test_methods_focused.each { |m| run_test m }
@@ -76,12 +76,12 @@ module GTK
 
     def log_inconclusive m
       self.inconclusive << {m: m}
-      log "Inconclusive."
+      log_yellow "Inconclusive."
     end
 
     def log_passed m
       self.passed << {m: m}
-      log "Passed."
+      log_green "Passed."
     end
 
     def log_no_tests_found
@@ -97,7 +97,7 @@ S
     end
 
     def log_test_running m
-      log "** Running: #{m}"
+      log_cyan "** Running: #{m}"
     end
 
     def test_signature_invalid_exception? e, m
@@ -127,24 +127,24 @@ S
     end
 
     def print_summary
-      log "** Summary"
-      log "*** Passed"
-      log "#{self.passed.length} test(s) passed."
-      self.passed.each { |h| log "**** :#{h[:m]}" }
-      log "*** Inconclusive"
+      log_cyan "** Summary"
+      log_green "*** Passed"
+      log_green "#{self.passed.length} test(s) passed."
+      self.passed.each { |h| log_green "**** :#{h[:m]}" }
+      log_yellow "*** Inconclusive"
       if self.inconclusive.length > 0
         log_once :assertion_ok_note, <<-S
 NOTE FOR INCONCLUSIVE TESTS: No assertion was performed in the test.
 Add assert.ok! at the end of the test if you are using your own assertions.
 S
       end
-      log "#{self.inconclusive.length} test(s) inconclusive."
-      self.inconclusive.each { |h| log "**** :#{h[:m]}" }
-      log "*** Failed"
-      log "#{self.failed.length} test(s) failed."
+      log_yellow "#{self.inconclusive.length} test(s) inconclusive."
+      self.inconclusive.each { |h| log_yellow "**** :#{h[:m]}" }
+      log_red "*** Failed"
+      log_red "#{self.failed.length} test(s) failed."
       self.failed.each do |h|
-        log "**** Test name: :#{h[:m]}"
-        log "#{h[:e].to_s.gsub("* ERROR:", "").strip}\n#{h[:e].__backtrace_to_org__}"
+        log_red "**** Test name: :#{h[:m]}"
+        log_red "#{h[:e].to_s.gsub("* ERROR:", "").strip}\n#{h[:e].__backtrace_to_org__}"
       end
     end
   end


### PR DESCRIPTION
I was running tests on my game and noticed they had no colors - this seemed like an easy improvement to make it easier to parse visually, so I added some.

As I was trying to validate the change, I discovered that none of my color codes were working... I am not sure if my terminal is misconfigured (I don't believe it is? Fairly stock iTerm on OS X) or not, but I've included the commit with changes I had to make to `log_with_color` to get it working as well.

Screenshot (the non-colorized outputs are from `puts` statements in my code):

<img width="622" alt="Screen Shot 2023-11-04 at 3 03 33 PM" src="https://github.com/DragonRuby/dragonruby-game-toolkit-contrib/assets/60324/bd4463f8-a91f-4f21-b447-177c1b6c1315">
