### PR TITLE
Fix Geometry circle methods

### DIFF
--- a/dragon/geometry.rb
+++ b/dragon/geometry.rb
@@ -787,38 +787,15 @@ S
       end
 
       def intersect_circle? circle_one, circle_two
-        circle_one_radius   = circle_one.radius if circle_one.respond_to? :radius
-        circle_one_radius ||= if circle_one.w <= circle_one.h
-                                circle_one.w / 2
-                              else
-                                circle_one.h / 2
-                              end
-        circle_two_radius   = circle_two.radius if circle_two.respond_to? :radius
-        circle_two_radius ||= if circle_two.w <= circle_one.h
-                                circle_two.w / 2
-                              else
-                                circle_two.h / 2
-                              end
+        resolved_circle_one = rect_to_circle circle_one
+        resolved_circle_two = rect_to_circle circle_two
 
-        circle_one_center = { x: circle_one.x + circle_one_radius,
-                              y: circle_one.y + circle_one_radius }
-        circle_two_center = { x: circle_two.x + circle_two_radius,
-                              y: circle_two.y + circle_two_radius }
+        circle_one_center = { x: resolved_circle_one.x + resolved_circle_one.radius,
+                              y: resolved_circle_one.y + resolved_circle_one.radius }
+        circle_two_center = { x: resolved_circle_two.x + resolved_circle_two.radius,
+                              y: resolved_circle_two.y + resolved_circle_two.radius }
 
-        if circle_one.respond_to?(:anchor_x) && circle_one.anchor_x
-          circle_one_center.x -= circle_one.anchor_x * circle_one_radius * 2
-        end
-        if circle_one.respond_to?(:anchor_y) && circle_one.anchor_y
-          circle_one_center.y -= circle_one.anchor_y * circle_one_radius * 2
-        end
-        if circle_two.respond_to?(:anchor_x) && circle_two.anchor_x
-          circle_two_center.x -= circle_two.anchor_x * circle_two_radius * 2
-        end
-        if circle_two.respond_to?(:anchor_y) && circle_two.anchor_y
-          circle_two_center.y -= circle_two.anchor_y * circle_two_radius * 2
-        end
-
-        distance_squared(circle_one_center, circle_two_center) <= (circle_one_radius + circle_two_radius)**2
+        distance_squared(circle_one_center, circle_two_center) <= (resolved_circle_one.radius + resolved_circle_two.radius)**2
       rescue Exception => e
         raise e, <<-S
 * ERROR:

--- a/dragon/geometry.rb
+++ b/dragon/geometry.rb
@@ -724,6 +724,68 @@ Geometry::line_normal for line #{line} and point #{point}.
 S
       end
 
+      def rect_to_circle rect
+        x = y = w = h = radius = nil
+
+        if circle? rect
+          radius = rect.radius
+          w = h = radius * 2
+        elsif rect? rect
+          w = rect.w
+          h = rect.h
+          radius = if w <= h
+                     w / 2
+                   else
+                     h / 2
+                   end
+        else
+          raise <<-S
+Parameter provided returned false for both Geometry::circle? and Geometry::rect?.
+S
+        end
+
+        x = rect.x
+        y = rect.y
+        x -= rect.anchor_x * w if rect.respond_to?(:anchor_x) && rect.anchor_x
+        y -= rect.anchor_y * h if rect.respond_to?(:anchor_y) && rect.anchor_y
+
+        { x: x, y: y, w: w, h: h, radius: radius }
+      rescue Exception => e
+        raise e, <<-S
+* ERROR:
+Geometry::rect_to_circle for rect #{rect}.
+#{e}
+Make sure the parameter adheres to one of the following:
+- A ~Hash~ with ~x~, ~y~, and ~radius~ (or an object that responds to ~x~, ~y~, and ~radius~).
+- A ~Hash~ with ~x~, ~y~, ~w~, and ~h~ (or an object that responds to ~x~, ~y~, ~w~, and ~h~).
+S
+      end
+
+      def rect? shape
+        shape.respond_to?(:x) &&
+        shape.respond_to?(:y) &&
+        shape.respond_to?(:w) &&
+        shape.respond_to?(:h)
+      rescue Exception => e
+        raise e, <<-S
+* ERROR:
+Geometry::rect? for shape #{shape}.
+#{e}
+S
+      end
+
+      def circle? shape
+        shape.respond_to?(:x) &&
+        shape.respond_to?(:y) &&
+        shape.respond_to?(:radius)
+      rescue Exception => e
+        raise e, <<-S
+* ERROR:
+Geometry::circle? for shape #{shape}.
+#{e}
+S
+      end
+
       def intersect_circle? circle_one, circle_two
         circle_one_radius   = circle_one.radius if circle_one.respond_to? :radius
         circle_one_radius ||= if circle_one.w <= circle_one.h

--- a/dragon/geometry.rb
+++ b/dragon/geometry.rb
@@ -785,14 +785,46 @@ S
       end
 
       def intersect_circle? circle_one, circle_two
-        resolved_circle_one = rect_to_circle circle_one
-        resolved_circle_two = rect_to_circle circle_two
-        distance_squared(circle_one, circle_two) <= (circle_one.radius + circle_two.radius)**2
+        circle_one_radius   = circle_one.radius if circle_one.respond_to? :radius
+        circle_one_radius ||= if circle_one.w <= circle_one.h
+                                circle_one.w / 2
+                              else
+                                circle_one.h / 2
+                              end
+        circle_two_radius   = circle_two.radius if circle_two.respond_to? :radius
+        circle_two_radius ||= if circle_two.w <= circle_one.h
+                                circle_two.w / 2
+                              else
+                                circle_two.h / 2
+                              end
+
+        circle_one_center = { x: circle_one.x + circle_one_radius,
+                              y: circle_one.y + circle_one_radius }
+        circle_two_center = { x: circle_two.x + circle_two_radius,
+                              y: circle_two.y + circle_two_radius }
+
+        if circle_one.respond_to?(:anchor_x) && circle_one.anchor_x
+          circle_one_center.x -= circle_one.anchor_x * circle_one_radius * 2
+        end
+        if circle_one.respond_to?(:anchor_y) && circle_one.anchor_y
+          circle_one_center.y -= circle_one.anchor_y * circle_one_radius * 2
+        end
+        if circle_two.respond_to?(:anchor_x) && circle_two.anchor_x
+          circle_two_center.x -= circle_two.anchor_x * circle_two_radius * 2
+        end
+        if circle_two.respond_to?(:anchor_y) && circle_two.anchor_y
+          circle_two_center.y -= circle_two.anchor_y * circle_two_radius * 2
+        end
+
+        distance_squared(circle_one_center, circle_two_center) <= (circle_one_radius + circle_two_radius)**2
       rescue Exception => e
         raise e, <<-S
 * ERROR:
 Geometry::intersect_circle? for circle_one #{circle_one} and circle_two #{circle_two}.
 #{e}
+Make sure the parameters adhere to one of the following:
+- A ~Hash~ with ~x~, ~y~, and ~radius~ (or an object that responds to ~x~, ~y~, and ~radius~).
+- A ~Hash~ with ~x~, ~y~, ~w~, and ~h~ (or an object that responds to ~x~, ~y~, ~w~, and ~h~).
 S
       end
 

--- a/dragon/geometry.rb
+++ b/dragon/geometry.rb
@@ -690,7 +690,10 @@ S
       end
 
       def circle_intersect_line? circle, line
-        center = { x: circle.x, y: circle.y }
+        center    = { x: circle.x + circle.radius, y: circle.y + circle.radius }
+        center.x -= circle.anchor_x * circle.w if circle.respond_to?(:anchor_x) && circle.anchor_x
+        center.y -= circle.anchor_y * circle.h if circle.respond_to?(:anchor_y) && circle.anchor_y
+
         closest_point = line_normal line, center
         result = distance_squared(center, closest_point) <= circle.radius**2
         return false if !result

--- a/dragon/geometry.rb
+++ b/dragon/geometry.rb
@@ -724,66 +724,6 @@ Geometry::line_normal for line #{line} and point #{point}.
 S
       end
 
-      def rect_to_circle rect
-        if circle? rect
-          rect
-        elsif rect? rect
-          x = rect.x
-          y = rect.y
-          anchor_shift_x = 0.5 - (rect.anchor_x || 0)
-          anchor_shift_y = 0.5 - (rect.anchor_y || 0)
-          x += rect.w * anchor_shift_x
-          y += rect.h * anchor_shift_y
-          radius = if rect.w <= rect.h
-                     rect.w / 2
-                   else
-                     rect.h / 2
-                   end
-          { x: x, y: y, radius: radius }
-        else
-          raise <<-S
-Parameter provided returned false for both Geometry::circle? and Geometry::rect?.
-S
-        end
-      rescue Exception => e
-        raise e, <<-S
-* ERROR:
-Geometry::rect_to_circle for rect #{rect}.
-#{e}
-Make sure the parameter adheres to one of the following:
-- A ~Hash~ with ~x~, ~y~, and ~radius~ (or an object that responds to ~x~, ~y~, and ~radius~).
-- A ~Hash~ with ~x~, ~y~, ~w~, ~h~, ~anchor_x~, and ~anchor_y~ (or an object that responds to ~x~, ~y~, ~w~, ~h~, ~anchor_x~, and ~anchor_y~).
-  If the parameter is a ~Hash~, ~anchor_x~ and ~anchor_y~ are optional and default to ~0~.
-S
-      end
-
-      def rect? shape
-        if shape.is_a? Hash
-          shape.w && shape.h
-        else
-          shape.respond_to?(:x) &&
-          shape.respond_to?(:y) &&
-          shape.respond_to?(:w) &&
-          shape.respond_to?(:h) &&
-          shape.respond_to?(:anchor_x) &&
-          shape.respond_to?(:anchor_y)
-        end
-      rescue Exception => e
-        raise e, <<-S
-* ERROR:
-Geometry::rect? for shape #{shape}.
-#{e}
-S
-      end
-
-      def circle? shape
-        if shape.is_a?(Hash)
-          !!shape.radius
-        else
-          shape.respond_to?(:radius)
-        end
-      end
-
       def intersect_circle? circle_one, circle_two
         circle_one_radius   = circle_one.radius if circle_one.respond_to? :radius
         circle_one_radius ||= if circle_one.w <= circle_one.h


### PR DESCRIPTION
A bunch of the new circle methods either work incorrectly or are inaccurate to the docs descriptions.

Fixed `circle_intersect_line?` and added ability to use `anchor_(x|y)`.

`rect_to_circle` would either return the input object if a `radius` property exists or a new hash with `{x:, y:, radius: }`, neither of which are what the docs says it should return which is a rectangle. But that's also counterintuitive to the method name so I changed it to always return a new hash with `{x:, y:, w:, h:, radius: }` for consistency. I also removed the necessity for `anchor_(x|y)` with inputs without a `radius` while allowing any input to use `anchor_(x|y)`.

To be honest, I just didn't know why `rect?` and `circle?` require truthy values for Hash inputs but only need `respond_to?` to be true for non Hash inputs and it bothered me so I simplified them.

Fixed `intersect_circle?` and removed the necessity for `anchor_(x|y)` with inputs without a `radius` while allowing any input to use `anchor_(x|y)`.